### PR TITLE
Feature/tags configs cleanup

### DIFF
--- a/config/sample_settings/general.json
+++ b/config/sample_settings/general.json
@@ -2,8 +2,7 @@
     "tooling_environment": {
         "name": "Tooling Account [dev]",
         "account_id": "323432554",
-        "region": "eu-central-1",
-        "environment_admin_email": "admindatalake@company.com"
+        "region": "eu-central-1"
     },
     "monitored_environments": [
         {

--- a/infra_monitored_account/app.py
+++ b/infra_monitored_account/app.py
@@ -17,6 +17,7 @@ app = cdk.App()
 InfraMonitoredStack(
     app,
     f"cf-{PROJECT_NAME}-InfraMonitoredStack-{STAGE_NAME}",
+    tags={"project_name": PROJECT_NAME, "stage_name": STAGE_NAME},
     project_name=PROJECT_NAME,
     stage_name=STAGE_NAME,
 )

--- a/infra_monitored_account/infra_monitored_account/infra_monitored_stack.py
+++ b/infra_monitored_account/infra_monitored_account/infra_monitored_stack.py
@@ -37,8 +37,8 @@ class InfraMonitoredStack(Stack):
             assumed_by=iam.ServicePrincipal("events.amazonaws.com"),
         )
 
-        tooling_account_id = general_config["tooling_environment"]["AccountId"]
-        tooling_account_region = general_config["tooling_environment"]["Region"]
+        tooling_account_id = general_config["tooling_environment"]["account_id"]
+        tooling_account_region = general_config["tooling_environment"]["region"]
         cross_account_event_bus_name = f"eventbus-{project_name}-alerting-{stage_name}"
         cross_account_event_bus_arn = f"arn:aws:events:{tooling_account_region}:{tooling_account_id}:event-bus/{cross_account_event_bus_name}"
         cross_account_bus_role.add_to_policy(

--- a/infra_monitored_account/infra_monitored_account/infra_monitored_stack.py
+++ b/infra_monitored_account/infra_monitored_account/infra_monitored_stack.py
@@ -1,6 +1,5 @@
 from aws_cdk import (
     Stack,
-    Tags,
     aws_iam as iam,
     aws_events as events,
     aws_events_targets as targets,
@@ -78,6 +77,3 @@ class InfraMonitoredStack(Stack):
 
         glue_alerting_event_rule.add_target(rule_target)
         step_functions_alerting_event_rule.add_target(rule_target)
-
-        Tags.of(self).add("stage_name", stage_name)
-        Tags.of(self).add("project_name", project_name)

--- a/infra_tooling_account/app.py
+++ b/infra_tooling_account/app.py
@@ -18,12 +18,14 @@ app = cdk.App()
 InfraToolingCommonStack(
     app,
     f"cf-{PROJECT_NAME}-InfraToolingCommonStack-{STAGE_NAME}",
+    tags={"project_name": PROJECT_NAME, "stage_name": STAGE_NAME},
     stage_name=STAGE_NAME,
     project_name=PROJECT_NAME,
 )
 InfraToolingAlertingStack(
     app,
     f"cf-{PROJECT_NAME}-InfraToolingAlertingStack-{STAGE_NAME}",
+    tags={"project_name": PROJECT_NAME, "stage_name": STAGE_NAME},
     stage_name=STAGE_NAME,
     project_name=PROJECT_NAME,
 )

--- a/infra_tooling_account/app.py
+++ b/infra_tooling_account/app.py
@@ -14,20 +14,24 @@ STAGE_NAME = os.environ["STAGE_NAME"]
 
 PROJECT_NAME = "salmon"
 
+TAGS = {"project_name": PROJECT_NAME, "stage_name": STAGE_NAME}
+
 app = cdk.App()
-InfraToolingCommonStack(
+common_stack = InfraToolingCommonStack(
     app,
     f"cf-{PROJECT_NAME}-InfraToolingCommonStack-{STAGE_NAME}",
-    tags={"project_name": PROJECT_NAME, "stage_name": STAGE_NAME},
+    tags=TAGS,
     stage_name=STAGE_NAME,
     project_name=PROJECT_NAME,
 )
-InfraToolingAlertingStack(
+alerting_stack = InfraToolingAlertingStack(
     app,
     f"cf-{PROJECT_NAME}-InfraToolingAlertingStack-{STAGE_NAME}",
-    tags={"project_name": PROJECT_NAME, "stage_name": STAGE_NAME},
+    tags=TAGS,
     stage_name=STAGE_NAME,
     project_name=PROJECT_NAME,
 )
+
+alerting_stack.add_dependency(common_stack)
 
 app.synth()

--- a/infra_tooling_account/infra_tooling_account/infra_tooling_alerting_stack.py
+++ b/infra_tooling_account/infra_tooling_account/infra_tooling_alerting_stack.py
@@ -1,11 +1,9 @@
 from aws_cdk import (
     Stack,
     Fn,
-    CfnOutput,
     aws_s3 as s3,
     aws_events as events,
     aws_events_targets as targets,
-    Tags,
     aws_lambda as lambda_,
     aws_iam as iam,
     aws_sns as sns,
@@ -70,17 +68,6 @@ class InfraToolingAlertingStack(Stack):
             timestream_database_arn=input_timestream_database_arn,
             alerting_lambda_event_rule=alerting_lambda_event_rule,
         )
-
-        output_internal_error_topic_arn = CfnOutput(
-            self,
-            "salmonInternalErrorTopicArn",
-            value=internal_error_topic.topic_arn,
-            description="The ARN of the Internal Error Topic",
-            export_name=f"output-{self.project_name}-internal-error-topic-arn-{self.stage_name}",
-        )
-
-        Tags.of(self).add("stage_name", self.stage_name)
-        Tags.of(self).add("project_name", self.project_name)
 
     def create_event_bus(self):
         alerting_bus = events.EventBus(

--- a/infra_tooling_account/infra_tooling_account/infra_tooling_alerting_stack.py
+++ b/infra_tooling_account/infra_tooling_account/infra_tooling_alerting_stack.py
@@ -91,7 +91,7 @@ class InfraToolingAlertingStack(Stack):
 
         monitored_account_ids = set(
             [
-                account["AccountId"]
+                account["account_id"]
                 for account in general_config["monitored_environments"]
             ]
         )

--- a/infra_tooling_account/infra_tooling_account/infra_tooling_common_stack.py
+++ b/infra_tooling_account/infra_tooling_account/infra_tooling_common_stack.py
@@ -2,7 +2,6 @@ from aws_cdk import (
     Stack,
     CfnOutput,
     Duration,
-    Tags,
     aws_s3 as s3,
     aws_s3_deployment as s3deploy,
     RemovalPolicy,
@@ -80,9 +79,6 @@ class InfraToolingCommonStack(Stack):
             description="The ARN of the Internal Error Topic",
             export_name=f"output-{self.project_name}-internal-error-topic-arn-{self.stage_name}",
         )
-
-        Tags.of(self).add("stage_name", self.stage_name)
-        Tags.of(self).add("project_name", self.project_name)
 
     def create_timestream_db(self):
         timestream_kms_key = kms.Key(


### PR DESCRIPTION
1. Removed internal error topic arn output from alerting stack (can't be two same outputs in the same app)
2. Passing tags to the stacks instead of tags applying commands duplication
3. Refactored monitored stack code to extract resources creation into methods
4. Adapted stacks to config file changes
5. Removed env admin email from sample configs, as we won't use them