### PR TITLE
new dependency added and s3 auto delete objects enabled

### DIFF
--- a/infra_tooling_account/infra_tooling_account/infra_tooling_common_stack.py
+++ b/infra_tooling_account/infra_tooling_account/infra_tooling_common_stack.py
@@ -35,6 +35,8 @@ class InfraToolingCommonStack(Stack):
             timestream_storage
         )
 
+        timestream_table_alert_events.add_dependency(timestream_storage)
+
         # Internal Error SNS topic
         internal_error_topic = sns.Topic(
             self,
@@ -141,6 +143,7 @@ class InfraToolingCommonStack(Stack):
             bucket_name=f"s3-{self.project_name}-settings-{self.stage_name}",
             block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
             removal_policy=RemovalPolicy.DESTROY,
+            auto_delete_objects=True,
         )
 
         s3deploy.BucketDeployment(


### PR DESCRIPTION
small fixes:

- added dependency to create timestream db before creating the table (before - the deployment failed since the table was created first)
- auto_delete_objects option during s3 bucket  creation was enabled in order to be able to delete the bucket via cdk destroy if needed. Before -  the delete failed since the bucket is not empty:
![image](https://github.com/Soname-Solutions/salmon/assets/150046345/7fded83b-4527-4b08-a321-b635e96fa56e) After:
![image](https://github.com/Soname-Solutions/salmon/assets/150046345/696638ae-a3a5-49eb-9d07-2c0219daaa05)

