### PR TITLE
Added AWSNaming convention

### DIFF
--- a/infra_monitored_account/infra_monitored_account/infra_monitored_stack.py
+++ b/infra_monitored_account/infra_monitored_account/infra_monitored_stack.py
@@ -6,6 +6,7 @@ from aws_cdk import (
 )
 from constructs import Construct
 
+from lib.aws.aws_naming import AWSNaming
 
 class InfraMonitoredStack(Stack):
     def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
@@ -29,7 +30,7 @@ class InfraMonitoredStack(Stack):
         cross_account_bus_role = iam.Role(
             self,
             "salmonCrossAccountPutEventsRole",
-            role_name=f"role-{self.project_name}-cross-account-put-events-{self.stage_name}",
+            role_name=AWSNaming.IAMRole(self, "cross-account-put-events"),
             description="Role assumed by EventBridge to put events to the centralized bus",
             assumed_by=iam.ServicePrincipal("events.amazonaws.com"),
         )
@@ -37,9 +38,8 @@ class InfraMonitoredStack(Stack):
         tooling_environment = self.general_settings_reader.tooling_environment
         tooling_account_id = tooling_environment["account_id"]
         tooling_account_region = tooling_environment["region"]
-        cross_account_event_bus_name = (
-            f"eventbus-{self.project_name}-alerting-{self.stage_name}"
-        )
+        cross_account_event_bus_name = AWSNaming.EventBus(self, "alerting")
+        
         cross_account_event_bus_arn = f"arn:aws:events:{tooling_account_region}:{tooling_account_id}:event-bus/{cross_account_event_bus_name}"
         cross_account_bus_role.add_to_policy(
             iam.PolicyStatement(
@@ -59,7 +59,7 @@ class InfraMonitoredStack(Stack):
         glue_alerting_event_rule = events.Rule(
             self,
             "salmonGlueAlertingEventRule",
-            rule_name=f"eventbusrule-{self.project_name}-glue-{self.stage_name}",
+            rule_name=AWSNaming.EventBusRule(self, "glue"),
             event_pattern=events.EventPattern(source=["aws.glue"]),
         )
 
@@ -67,7 +67,7 @@ class InfraMonitoredStack(Stack):
         step_functions_alerting_event_rule = events.Rule(
             self,
             "salmonStepFunctionsAlertingEventRule",
-            rule_name=f"eventbusrule-{self.project_name}-step-functions-{self.stage_name}",
+            rule_name=AWSNaming.EventBusRule(self, "step-functions"),
             event_pattern=events.EventPattern(source=["aws.states"]),
         )
 

--- a/infra_tooling_account/infra_tooling_account/infra_tooling_alerting_stack.py
+++ b/infra_tooling_account/infra_tooling_account/infra_tooling_alerting_stack.py
@@ -15,7 +15,7 @@ from constructs import Construct
 import os
 
 from lib.core.constants import CDKDeployExclusions
-
+from lib.aws.aws_naming import AWSNaming
 
 class InfraToolingAlertingStack(Stack):
     def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:

--- a/infra_tooling_account/infra_tooling_account/infra_tooling_common_stack.py
+++ b/infra_tooling_account/infra_tooling_account/infra_tooling_common_stack.py
@@ -17,7 +17,7 @@ from aws_cdk import (
 from constructs import Construct
 import os
 
-from lib.core.constants import CDKDeployExclusions
+from lib.core.constants import CDKDeployExclusions, TimestreamRetention
 from lib.aws.aws_naming import AWSNaming
 
 
@@ -124,8 +124,8 @@ class InfraToolingCommonStack(Stack):
 
     def create_timestream_tables(self, timestream_storage):
         retention_properties_property = timestream.CfnTable.RetentionPropertiesProperty(
-            magnetic_store_retention_period_in_days="365",
-            memory_store_retention_period_in_hours="240",
+            magnetic_store_retention_period_in_days=TimestreamRetention.MagneticStoreRetentionPeriodInDays,
+            memory_store_retention_period_in_hours=TimestreamRetention.MemoryStoreRetentionPeriodInHours,
         )
         alert_events_table = timestream.CfnTable(
             self,

--- a/infra_tooling_account/infra_tooling_account/infra_tooling_common_stack.py
+++ b/infra_tooling_account/infra_tooling_account/infra_tooling_common_stack.py
@@ -18,6 +18,7 @@ from constructs import Construct
 import os
 
 from lib.core.constants import CDKDeployExclusions
+from lib.aws.aws_naming import AWSNaming
 
 
 class InfraToolingCommonStack(Stack):
@@ -41,7 +42,7 @@ class InfraToolingCommonStack(Stack):
         internal_error_topic = sns.Topic(
             self,
             "salmonInternalErrorTopic",
-            topic_name=f"topic-{self.project_name}-internal-error-{self.stage_name}",
+            topic_name=AWSNaming.SNSTopic(self, "internal-error"),
         )
 
         # Notification SQS Queue
@@ -49,7 +50,7 @@ class InfraToolingCommonStack(Stack):
         notification_queue = sqs.Queue(
             self,
             "salmonNotificationQueue",
-            queue_name=f"queue-{self.project_name}-notification-{self.stage_name}",
+            queue_name=AWSNaming.SQSQueue(self, "notification"),
             visibility_timeout=Duration.seconds(60),
         )
 
@@ -62,7 +63,7 @@ class InfraToolingCommonStack(Stack):
             "salmonSettingsBucketArn",
             value=settings_bucket.bucket_arn,
             description="The ARN of the Settings S3 Bucket",
-            export_name=f"output-{self.project_name}-settings-bucket-arn-{self.stage_name}",
+            export_name=AWSNaming.CfnOutput(self, "settings-bucket-arn"),
         )
 
         output_timestream_database_arn = CfnOutput(
@@ -70,7 +71,7 @@ class InfraToolingCommonStack(Stack):
             "salmonTimestreamDBArn",
             value=timestream_storage.attr_arn,
             description="The ARN of the Metrics and Events Storage",
-            export_name=f"output-{self.project_name}-metrics-events-storage-arn-{self.stage_name}",
+            export_name=AWSNaming.CfnOutput(self, "metrics-events-storage-arn"),
         )
 
         output_timestream_database_name = CfnOutput(
@@ -78,7 +79,7 @@ class InfraToolingCommonStack(Stack):
             "salmonTimestreamDBName",
             value=timestream_storage.database_name,
             description="DB Name of the Metrics and Events Storage",
-            export_name=f"output-{self.project_name}-metrics-events-db-name-{self.stage_name}",
+            export_name=AWSNaming.CfnOutput(self, "metrics-events-db-name"),
         )
 
         output_timestream_alerts_table_name = CfnOutput(
@@ -86,7 +87,7 @@ class InfraToolingCommonStack(Stack):
             "salmonTimestreamAlertsTableName",
             value=timestream_table_alert_events.table_name,
             description="Table Name for Alert Events storage",
-            export_name=f"output-{self.project_name}-alert-events-table-name-{self.stage_name}",
+            export_name=AWSNaming.CfnOutput(self, "alert-events-table-name"),
         )
 
         output_notification_queue_arn = CfnOutput(
@@ -94,7 +95,7 @@ class InfraToolingCommonStack(Stack):
             "salmonNotificationQueueArn",
             value=notification_queue.queue_arn,
             description="The ARN of the Notification SQS Queue",
-            export_name=f"output-{self.project_name}-notification-queue-arn-{self.stage_name}",
+            export_name=AWSNaming.CfnOutput(self, "notification-queue-arn"),
         )
 
         output_internal_error_topic_arn = CfnOutput(
@@ -102,20 +103,20 @@ class InfraToolingCommonStack(Stack):
             "salmonInternalErrorTopicArn",
             value=internal_error_topic.topic_arn,
             description="The ARN of the Internal Error Topic",
-            export_name=f"output-{self.project_name}-internal-error-topic-arn-{self.stage_name}",
+            export_name=AWSNaming.CfnOutput(self, "internal-error-topic-arn"),
         )
 
     def create_timestream_db(self):
         timestream_kms_key = kms.Key(
             self,
             "salmonTimestreamKMSKey",
-            alias=f"key-{self.project_name}-timestream-{self.stage_name}",
+            alias=AWSNaming.KMSKey(self, "timestream"),
             description="Key that protects Timestream data",
         )
         timestream_storage = timestream.CfnDatabase(
             self,
             "salmonTimestreamDB",
-            database_name=f"timestream-{self.project_name}-metrics-events-storage-{self.stage_name}",
+            database_name=AWSNaming.TimestreamDB(self, "metrics-events-storage"),  
             kms_key_id=timestream_kms_key.key_id,
         )
 
@@ -140,7 +141,7 @@ class InfraToolingCommonStack(Stack):
         settings_bucket = s3.Bucket(
             self,
             "salmonSettingsBucket",
-            bucket_name=f"s3-{self.project_name}-settings-{self.stage_name}",
+            bucket_name=AWSNaming.S3Bucket(self, "settings"),
             block_public_access=s3.BlockPublicAccess.BLOCK_ALL,
             removal_policy=RemovalPolicy.DESTROY,
             auto_delete_objects=True,
@@ -162,7 +163,7 @@ class InfraToolingCommonStack(Stack):
             self,
             "salmonNotificationLambdaRole",
             assumed_by=iam.ServicePrincipal("lambda.amazonaws.com"),
-            role_name=f"role-{self.project_name}-notification-lambda-{self.stage_name}",
+            role_name=AWSNaming.IAMRole(self, "notification-lambda"),
         )
 
         notification_lambda_role.add_managed_policy(
@@ -205,7 +206,7 @@ class InfraToolingCommonStack(Stack):
         notification_lambda = lambda_.Function(
             self,
             "salmonNotificationLambda",
-            function_name=f"lambda-{self.project_name}-notification-{self.stage_name}",
+            function_name=AWSNaming.LambdaFunction(self, "notification"),
             code=lambda_.Code.from_asset(
                 notification_lambda_path,
                 exclude=CDKDeployExclusions.LAMBDA_ASSET_EXCLUSIONS,

--- a/infra_tooling_account/infra_tooling_account/infra_tooling_common_stack.py
+++ b/infra_tooling_account/infra_tooling_account/infra_tooling_common_stack.py
@@ -116,7 +116,7 @@ class InfraToolingCommonStack(Stack):
         timestream_storage = timestream.CfnDatabase(
             self,
             "salmonTimestreamDB",
-            database_name=AWSNaming.TimestreamDB(self, "metrics-events-storage"),  
+            database_name=AWSNaming.TimestreamDB(self, "metrics-events-storage"),
             kms_key_id=timestream_kms_key.key_id,
         )
 
@@ -132,7 +132,7 @@ class InfraToolingCommonStack(Stack):
             "AlertEventsTable",
             database_name=timestream_storage.database_name,
             retention_properties=retention_properties_property,
-            table_name="alert-events",
+            table_name=AWSNaming.TimestreamTable(self, "alert-events"),
         )
 
         return alert_events_table

--- a/infra_tooling_account/infra_tooling_account/infra_tooling_monitoring_stack.py
+++ b/infra_tooling_account/infra_tooling_account/infra_tooling_monitoring_stack.py
@@ -15,7 +15,7 @@ from constructs import Construct
 import os
 
 from lib.core.constants import CDKDeployExclusions
-
+from lib.aws.aws_naming import AWSNaming
 
 class InfraToolingMonitoringStack(Stack):
     """

--- a/infra_tooling_account/infra_tooling_account/infra_tooling_monitoring_stack.py
+++ b/infra_tooling_account/infra_tooling_account/infra_tooling_monitoring_stack.py
@@ -17,6 +17,7 @@ import os
 from lib.core.constants import CDKDeployExclusions
 from lib.aws.aws_naming import AWSNaming
 
+
 class InfraToolingMonitoringStack(Stack):
     """
     This class represents a stack for infrastructure tooling and monitoring in AWS CloudFormation.
@@ -73,7 +74,7 @@ class InfraToolingMonitoringStack(Stack):
             schedule=events.Schedule.rate(
                 Duration.minutes(metrics_collection_interval_min)
             ),
-            rule_name=f"rule-{self.project_name}-metrics-extract-cron-{self.stage_name}",
+            rule_name=AWSNaming.EventBusRule(self, "metrics-extract-cron"),
         )
         rule.add_target(targets.LambdaFunction(extract_metrics_orch_lambda))
 
@@ -86,15 +87,15 @@ class InfraToolingMonitoringStack(Stack):
             tuple: A tuple containing references to the settings S3 bucket, internal error topic, and Timestream database ARN.
         """
         input_settings_bucket_arn = Fn.import_value(
-            f"output-{self.project_name}-settings-bucket-arn-{self.stage_name}"
+            AWSNaming.CfnOutput(self, "settings-bucket-arn")
         )
 
         input_timestream_database_arn = Fn.import_value(
-            f"output-{self.project_name}-metrics-events-storage-arn-{self.stage_name}"
+            AWSNaming.CfnOutput(self, "metrics-events-storage-arn")
         )
 
         input_internal_error_topic_arn = Fn.import_value(
-            f"output-{self.project_name}-internal-error-topic-arn-{self.stage_name}"
+            AWSNaming.CfnOutput(self, "internal-error-topic-arn")
         )
 
         # Settings S3 Bucket Import
@@ -151,7 +152,7 @@ class InfraToolingMonitoringStack(Stack):
             self,
             "extract-metricsLambdaRole",
             assumed_by=iam.ServicePrincipal("lambda.amazonaws.com"),
-            role_name=f"role-{self.project_name}-extract-metrics-lambda-{self.stage_name}",
+            role_name=AWSNaming.IAMRole(self, "extract-metrics-lambda"),
         )
 
         extract_metrics_lambda_role.add_managed_policy(
@@ -188,7 +189,7 @@ class InfraToolingMonitoringStack(Stack):
         extract_metrics_lambda = lambda_.Function(
             self,
             "salmonExtractMetricsLambda",
-            function_name=f"lambda-{self.project_name}-extract-metrics-{self.stage_name}",
+            function_name=AWSNaming.LambdaFunction(self, "extract-metrics"),
             code=lambda_.Code.from_asset(
                 extract_metrics_lambda_path,
                 exclude=CDKDeployExclusions.LAMBDA_ASSET_EXCLUSIONS,
@@ -207,7 +208,7 @@ class InfraToolingMonitoringStack(Stack):
         extract_metrics_orch_lambda = lambda_.Function(
             self,
             "salmonExtractMetricsOrchLambda",
-            function_name=f"lambda-{self.project_name}-extract-metrics-orch-{self.stage_name}",
+            function_name=AWSNaming.LambdaFunction(self, "extract-metrics-orch"),
             code=lambda_.Code.from_asset(
                 extract_metrics_orch_lambda_path,
                 exclude=CDKDeployExclusions.LAMBDA_ASSET_EXCLUSIONS,

--- a/src/lib/aws/aws_naming.py
+++ b/src/lib/aws/aws_naming.py
@@ -1,0 +1,82 @@
+class AWSNaming:
+    @classmethod
+    def __get_project_and_stage(cls, stack_obj: object):
+        # Check if project_name and stage_name attributes exist in stack_obj
+        if hasattr(stack_obj, "project_name") and hasattr(stack_obj, "stage_name"):
+            return stack_obj.project_name, stack_obj.stage_name
+        else:
+            raise AttributeError(
+                "stack_obj is missing 'project_name' or 'stage_name' attributes"
+            )
+
+    @classmethod
+    def __resource_name_with_check(
+        cls, stack_obj: object, prefix: str, meaning: str
+    ) -> str:
+        project_name, stage_name = AWSNaming.__get_project_and_stage(stack_obj)
+
+        outp = f"{prefix}-{project_name}-{meaning}-{stage_name}"
+
+        # todo: if name longer than XX symbols (90? - AWS Limit) - throw an error
+
+        return outp
+
+    @classmethod
+    def CfnOutput(cls, stack_obj: object, meaning: str) -> str:
+        prefix = "output"
+        return AWSNaming.__resource_name_with_check(stack_obj, prefix, meaning)
+
+    @classmethod
+    def EventBus(cls, stack_obj: object, meaning: str) -> str:
+        prefix = "eventbus"
+        return AWSNaming.__resource_name_with_check(stack_obj, prefix, meaning)
+
+    @classmethod
+    def EventBusRule(cls, stack_obj: object, meaning: str) -> str:
+        prefix = "eventbusrule"
+        return AWSNaming.__resource_name_with_check(stack_obj, prefix, meaning)
+
+    @classmethod
+    def IAMPolicy(cls, stack_obj: object, meaning: str) -> str:
+        prefix = "policy"
+        return AWSNaming.__resource_name_with_check(stack_obj, prefix, meaning)
+
+    @classmethod
+    def IAMRole(cls, stack_obj: object, meaning: str) -> str:
+        prefix = "role"
+        return AWSNaming.__resource_name_with_check(stack_obj, prefix, meaning)
+
+    @classmethod
+    def KMSKey(cls, stack_obj: object, meaning: str) -> str:
+        prefix = "key"
+        return AWSNaming.__resource_name_with_check(stack_obj, prefix, meaning)
+
+    @classmethod
+    def LambdaFunction(cls, stack_obj: object, meaning: str) -> str:
+        prefix = "lambda"
+        return AWSNaming.__resource_name_with_check(stack_obj, prefix, meaning)
+
+    @classmethod
+    def S3Bucket(cls, stack_obj: object, meaning: str) -> str:
+        prefix = "s3"
+        return AWSNaming.__resource_name_with_check(stack_obj, prefix, meaning)
+
+    @classmethod
+    def SNSTopic(cls, stack_obj: object, meaning: str) -> str:
+        prefix = "topic"
+        return AWSNaming.__resource_name_with_check(stack_obj, prefix, meaning)
+
+    @classmethod
+    def SQSQueue(cls, stack_obj: object, meaning: str) -> str:
+        prefix = "queue"
+        return AWSNaming.__resource_name_with_check(stack_obj, prefix, meaning)
+
+    @classmethod
+    def TimestreamDB(cls, stack_obj: object, meaning: str) -> str:
+        prefix = "timestream"
+        return AWSNaming.__resource_name_with_check(stack_obj, prefix, meaning)
+
+    @classmethod
+    def TimestreamTable(cls, stack_obj: object, meaning: str) -> str:
+        prefix = "tstable"
+        return AWSNaming.__resource_name_with_check(stack_obj, prefix, meaning)

--- a/src/lib/aws/aws_naming.py
+++ b/src/lib/aws/aws_naming.py
@@ -17,8 +17,6 @@ class AWSNaming:
 
         outp = f"{prefix}-{project_name}-{meaning}-{stage_name}"
 
-        # todo: if name longer than XX symbols (90? - AWS Limit) - throw an error
-
         return outp
 
     @classmethod

--- a/src/lib/core/constants.py
+++ b/src/lib/core/constants.py
@@ -12,6 +12,9 @@ class Settings:
         "step_functions",
     ]
 
+class TimestreamRetention:
+    MagneticStoreRetentionPeriodInDays = "365"
+    MemoryStoreRetentionPeriodInHours = "240"
 
 class CDKDeployExclusions:
     LAMBDA_ASSET_EXCLUSIONS = [".venv/", "__pycache__/"]


### PR DESCRIPTION
 - Added class representing AWSNaming conventions (lib.aws.aws_naming)
 - Changed all stacks from hard-coded names to AWSNaming methods references
 - Fix tech debt task: "Timestream table retention_properties_property (365 days/240 hours) - move to constants"