### PR TITLE
add grafana stack

### DIFF
--- a/config/sample_settings/general.json
+++ b/config/sample_settings/general.json
@@ -3,7 +3,9 @@
         "name": "Tooling Account [<<env>>]",
         "account_id": "<<tooling_account_id>>",
         "region": "eu-central-1",
-        "metrics_collection_interval_min" : 5
+        "metrics_collection_interval_min" : 5,
+        "grafana_vpc_id": "<<vpc_id>>", 
+        "grafana_security_group_id": "<<security_group_id>>"
     },
     "monitored_environments": [
         {

--- a/infra_tooling_account/infra_tooling_account/grafana/sample_dashboard.json
+++ b/infra_tooling_account/infra_tooling_account/grafana/sample_dashboard.json
@@ -1,0 +1,137 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 3,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": "Amazon-Timestream-glue_jobs",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "database": "\"timestream-salmon-metrics-events-storage-devay\"",
+          "datasource": "Amazon-Timestream-glue_jobs",
+          "measure": "job_execution",
+          "rawQuery": "SELECT * FROM $__database.$__table LIMIT 10",
+          "refId": "A",
+          "table": "\"tstable-glue_jobs-metrics\""
+        }
+      ],
+      "title": "Glue Jobs",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 38,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "hide": 2,
+        "name": "query0",
+        "query": "",
+        "skipUrlSync": false,
+        "type": "constant"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "New dashboard",
+  "version": 3,
+  "weekStart": ""
+}

--- a/infra_tooling_account/infra_tooling_account/grafana/sample_user_data.sh
+++ b/infra_tooling_account/infra_tooling_account/grafana/sample_user_data.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# copy grafana configurations to S3 bucket
+aws s3 cp s3://{settings_bucket_name}/settings/grafana/conf/datasources.yaml /opt/bitnami/grafana/conf/provisioning/datasources
+aws s3 cp s3://{settings_bucket_name}/settings/grafana/conf/dashboards.yaml /opt/bitnami/grafana/conf/provisioning/dashboards
+aws s3 cp s3://{settings_bucket_name}/settings/grafana/dashboards/ /opt/bitnami/grafana/data --recursive
+
+# get Grafana admin password from Secret Manager and apply it
+grafana_admin_password=$(aws secretsmanager get-secret-value --region {region} --secret-id {grafana_admin_secret_name} --query 'SecretString' --output text | jq -r '.password' )
+sudo /opt/bitnami/grafana/bin/grafana cli --homepath=/opt/bitnami/grafana admin reset-admin-password ${grafana_admin_password} 
+
+# install grafana-timestream-datasource plugin and restart Grafana 
+sudo /opt/bitnami/grafana/bin/grafana cli --pluginsDir /opt/bitnami/grafana/data/plugins plugins install grafana-timestream-datasource
+sudo /opt/bitnami/ctlscript.sh restart

--- a/infra_tooling_account/infra_tooling_account/infra_tooling_grafana_stack.py
+++ b/infra_tooling_account/infra_tooling_account/infra_tooling_grafana_stack.py
@@ -1,0 +1,386 @@
+import yaml
+import json
+from aws_cdk import (
+    Stack,
+    CfnOutput,
+    Fn,
+    aws_s3 as s3,
+    aws_iam as iam,
+    aws_ec2 as ec2,
+    aws_s3_deployment as s3deploy,
+    aws_secretsmanager as secretsmanager,
+)
+from constructs import Construct
+from lib.aws.aws_naming import AWSNaming
+from lib.settings.settings import Settings
+from lib.core.constants import SettingConfigs
+from lib.core.grafana_config_generator import (
+    generate_dashboard_model,
+    generate_datasources_config_section,
+    generate_dashboards_config_section,
+    generate_user_data_script,
+)
+
+
+class InfraToolingGrafanaStack(Stack):
+    """
+    This class represents a stack for Grafana instance in AWS CloudFormation.
+
+    Attributes:
+        stage_name (str): The stage name of the deployment, used for naming resources.
+        project_name (str): The name of the project, used for naming resources.
+
+    """
+
+    def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
+        """
+        Initialize the GrafanaStack.
+
+        Args:
+            scope (Construct): The CDK app or stack that this stack is a part of.
+            construct_id (str): The identifier for this stack.
+            **kwargs: Arbitrary keyword arguments. Specifically looks for:
+                - project_name (str): The name of the project. Used for naming resources. Defaults to None.
+                - stage_name (str): The name of the deployment stage. Used for naming resources. Defaults to None.
+                - settings (Tuple): Tuple containing settings. Defaults to None.
+
+        """
+        self.stage_name = kwargs.pop("stage_name", None)
+        self.project_name = kwargs.pop("project_name", None)
+        self.settings: Settings = kwargs.pop("settings", None)
+
+        super().__init__(scope, construct_id, **kwargs)
+
+        (
+            input_timestream_database_arn,
+            input_timestream_kms_key_arn,
+            input_settings_bucket_arn,
+            settings_bucket,
+        ) = self.get_common_stack_references()
+
+        (
+            grafana_vpc_id,
+            grafana_security_group_id,
+        ) = self.settings.get_grafana_mandatory_settings()
+
+        (
+            grafana_key_pair_name,
+            grafana_bitnami_image,
+            grafana_instance_type,
+        ) = self.settings.get_grafana_optional_settings()
+
+        (
+            grafana_admin_secret_name,
+            grafana_admin_secret_arn,
+        ) = self.create_grafana_admin_secret()
+
+        # Create Grafana key pair if not provided
+        if not grafana_key_pair_name:
+            grafana_key_pair_name = self.create_grafana_key_pair()
+
+        self.prepare_and_upload_grafana_configuration_files(settings_bucket)
+
+        grafana_instance = self.create_grafana_instance(
+            grafana_vpc_id=grafana_vpc_id,
+            grafana_security_group_id=grafana_security_group_id,
+            input_timestream_kms_key_arn=input_timestream_kms_key_arn,
+            input_timestream_database_arn=input_timestream_database_arn,
+            input_settings_bucket_arn=input_settings_bucket_arn,
+            grafana_admin_secret_name=grafana_admin_secret_name,
+            grafana_admin_secret_arn=grafana_admin_secret_arn,
+            grafana_bitnami_image=grafana_bitnami_image,
+            grafana_key_pair_name=grafana_key_pair_name,
+            grafana_instance_type=grafana_instance_type,
+            settings_bucket_name=settings_bucket.bucket_name,
+        )
+
+        output_grafana_instance_public_ip = CfnOutput(
+            self,
+            "GrafanaPublicIp",
+            value=grafana_instance.instance_public_ip,
+            description="The Public IP of the Grafana Instance",
+            # To sign in to Grafana, go to http://<grafana-instance-public-ip>:3000
+            export_name=AWSNaming.CfnOutput(self, "grafana-instance-public-ip"),
+        )
+
+    def get_common_stack_references(self) -> tuple[str, str, str, s3.Bucket]:
+        """
+        Retrieves common stack references required for the stack's operations.
+        These include the Timestream database ARN, Timestream KMS key ARN, settings S3 bucket and its ARN.
+
+        Returns:
+            tuple: A tuple containing references to the Timestream database ARN, Timestream KMS key ARN,
+                   settings S3 bucket and its ARN.
+        """
+
+        input_timestream_database_arn = Fn.import_value(
+            AWSNaming.CfnOutput(self, "metrics-events-storage-arn")
+        )
+        input_timestream_kms_key_arn = Fn.import_value(
+            AWSNaming.CfnOutput(self, "metrics-events-kms-key-arn")
+        )
+        input_settings_bucket_arn = Fn.import_value(
+            AWSNaming.CfnOutput(self, "settings-bucket-arn")
+        )
+
+        settings_bucket = s3.Bucket.from_bucket_arn(
+            self,
+            "salmonSettingsBucket",
+            bucket_arn=input_settings_bucket_arn,
+        )
+
+        return (
+            input_timestream_database_arn,
+            input_timestream_kms_key_arn,
+            input_settings_bucket_arn,
+            settings_bucket,
+        )
+
+    def create_grafana_admin_secret(self) -> tuple[str, str]:
+        """
+        Creates Grafana admin password in Secrets Manager.
+
+        Returns:
+            tuple: A tuple containing Grafana admin secret name and its ARN
+        """
+        grafana_admin_secret = secretsmanager.Secret(
+            self,
+            "GrafanaSecret",
+            secret_name=AWSNaming.SM(self, "grafana-secret"),
+            description="Grafana secret stored in AWS Secrets Manager",
+            generate_secret_string=secretsmanager.SecretStringGenerator(
+                include_space=False,
+                generate_string_key="password",
+                password_length=20,
+                secret_string_template='{"username":"admin"}',
+            ),
+        )
+
+        return grafana_admin_secret.secret_name, grafana_admin_secret.secret_arn
+
+    def create_grafana_key_pair(self) -> str:
+        """
+        Creates Key Pair for Grafana instance.
+
+        Returns:
+            str: Key Pair name
+        """
+        grafana_key_pair = ec2.CfnKeyPair(
+            self,
+            "GrafanaKeyPair",
+            key_name=AWSNaming.KMSKey(self, "grafana-key-pair"),
+        )
+
+        return grafana_key_pair.key_name
+
+    def prepare_and_upload_grafana_configuration_files(self, settings_bucket) -> None:
+        """
+        Generates and uploads Grafana configuration files to S3 bucket.
+        For each Service, a separate dashboard and data source will be provisioned.
+        The files will be uploaded to settings/grafana dedicated folder.
+
+        Args:
+            settings_bucket (s3.Bucket): Settings S3 Bucket
+        """
+        metric_table_names = {x: f"{x}-metrics" for x in SettingConfigs.RESOURCE_TYPES}
+        services = metric_table_names.keys()
+        timestream_database_name = AWSNaming.TimestreamDB(
+            self, "metrics-events-storage"
+        )
+
+        # Generate Dashboard JSON model for each Service
+        for i, service in enumerate(services):
+            timestream_table_name = AWSNaming.TimestreamTable(
+                self, metric_table_names[service]
+            )
+            dashboard_data = generate_dashboard_model(
+                service, timestream_database_name, timestream_table_name
+            )
+
+            # Upload to S3 settings/grafana/dashboards bucket
+            s3deploy.BucketDeployment(
+                self,
+                f"GrafanaDashboardsDeployment{i}",
+                sources=[
+                    s3deploy.Source.data(
+                        f"{service}_dashboard.json",
+                        json.dumps(dashboard_data, sort_keys=False),
+                    )
+                ],
+                destination_bucket=settings_bucket,
+                destination_key_prefix="settings/grafana/dashboards",
+                prune=False,
+            )
+
+        # Generate Data sources and Dashboards YAML config files
+        datasources_sections = [
+            generate_datasources_config_section(
+                service=service,
+                region=Stack.of(self).region,
+                timestream_database_name=timestream_database_name,
+                timestream_table_name=AWSNaming.TimestreamTable(
+                    self, metric_table_names[service]
+                ),
+            )
+            for service in services
+        ]
+        dashboards_sections = [
+            generate_dashboards_config_section(service) for service in services
+        ]
+        datasources_config = {"apiVersion": 1, "datasources": datasources_sections}
+        dashboards_config = {"apiVersion": 1, "providers": dashboards_sections}
+
+        # Upload to S3 settings/grafana/conf bucket
+        s3deploy.BucketDeployment(
+            self,
+            "GrafanaYamlConfigsDeployment",
+            sources=[
+                s3deploy.Source.data(
+                    "datasources.yaml",
+                    yaml.dump(
+                        datasources_config, default_flow_style=False, sort_keys=False
+                    ),
+                ),
+                s3deploy.Source.data(
+                    "dashboards.yaml",
+                    yaml.dump(
+                        dashboards_config, default_flow_style=False, sort_keys=False
+                    ),
+                ),
+            ],
+            destination_bucket=settings_bucket,
+            destination_key_prefix="settings/grafana/conf",
+        )
+
+    def create_grafana_instance(
+        self,
+        grafana_vpc_id: str,
+        grafana_security_group_id: str,
+        input_timestream_kms_key_arn: str,
+        input_timestream_database_arn: str,
+        input_settings_bucket_arn: str,
+        grafana_admin_secret_arn: str,
+        grafana_instance_type: str,
+        grafana_bitnami_image: str,
+        grafana_key_pair_name: str,
+        settings_bucket_name: str,
+        grafana_admin_secret_name: str,
+    ) -> ec2.Instance:
+        """Creates Grafana instance with the provisioned dashboards.
+
+        Args:
+            grafana_vpc_id (str): VPC ID for Grafana instance
+            grafana_security_group_id (str): Security Group ID for Grafana instance
+            input_timestream_kms_key_arn (str): ARN of Timestream KMS Key
+            input_timestream_database_arn (str): ARN of Timestream DB
+            input_settings_bucket_arn (str): ARN of Settings S3 Bucket
+            grafana_admin_secret_arn (str): ARN of Grafana secret
+            grafana_instance_type (str): Grafana Instance type
+            grafana_image (str): Bitnami Grafana image from AWS Marketplace
+            grafana_key_pair_name (str): Grafana Key Pair name
+            settings_bucket_name (str): Settings S3 Bucket name
+            grafana_admin_secret_name (str): Grafana secret name
+
+        Returns:
+            ec2.Instance: Grafana Instance
+        """
+        # Import the VPC, security group provided
+        vpc = ec2.Vpc.from_lookup(self, "VpcImport", vpc_id=grafana_vpc_id)
+        security_group = ec2.SecurityGroup.from_lookup_by_id(
+            self, "SecurityGroupImport", security_group_id=grafana_security_group_id
+        )
+
+        # Create Grafana Role
+        grafana_role = iam.Role(
+            self,
+            "GrafanaInstanceRole",
+            assumed_by=iam.ServicePrincipal("ec2.amazonaws.com"),
+            description="Role assumed by Grafana instance",
+            role_name=AWSNaming.IAMRole(self, "grafana-instance"),
+        )
+
+        grafana_role.add_to_policy(
+            # to be able to decrypt data from Timestream DB
+            iam.PolicyStatement(
+                actions=["kms:Decrypt"],
+                effect=iam.Effect.ALLOW,
+                resources=[input_timestream_kms_key_arn],
+            )
+        )
+        grafana_role.add_to_policy(
+            # to be able to make Timestream API calls from Grafana instance
+            iam.PolicyStatement(
+                actions=[
+                    "timestream:DescribeEndpoints",
+                    "timestream:ListDatabases",
+                    "timestream:SelectValues",
+                ],
+                effect=iam.Effect.ALLOW,
+                resources=["*"],
+            )
+        )
+        grafana_role.add_to_policy(
+            # to be able to describe Timestream DB and list its tables
+            iam.PolicyStatement(
+                actions=["timestream:ListTables", "timestream:DescribeDatabase"],
+                effect=iam.Effect.ALLOW,
+                resources=[input_timestream_database_arn],
+            )
+        )
+        grafana_role.add_to_policy(
+            # to be able to read data from Timestream tables and list their measures
+            iam.PolicyStatement(
+                actions=[
+                    "timestream:Select",
+                    "timestream:ListMeasures",
+                    "timestream:DescribeTable",
+                ],
+                effect=iam.Effect.ALLOW,
+                resources=[f"{input_timestream_database_arn}/table/*"],
+            )
+        )
+        grafana_role.add_to_policy(
+            # to be able to list configuration files in S3 bucket
+            iam.PolicyStatement(
+                actions=["s3:ListBucket"],
+                effect=iam.Effect.ALLOW,
+                resources=[input_settings_bucket_arn],
+            )
+        )
+        grafana_role.add_to_policy(
+            # to be able to get configuration files from S3 bucket
+            iam.PolicyStatement(
+                actions=["s3:GetObject"],
+                effect=iam.Effect.ALLOW,
+                resources=[f"{input_settings_bucket_arn}/*"],
+            )
+        )
+        grafana_role.add_to_policy(
+            # to be able to read Grafana admin password from Secrets Manager
+            iam.PolicyStatement(
+                actions=["secretsmanager:GetSecretValue"],
+                effect=iam.Effect.ALLOW,
+                resources=[grafana_admin_secret_arn],
+            )
+        )
+
+        grafana_instance = ec2.Instance(
+            self,
+            "GrafanaInstance",
+            instance_type=ec2.InstanceType(grafana_instance_type),
+            machine_image=ec2.MachineImage.lookup(name=grafana_bitnami_image),
+            vpc=vpc,
+            instance_name=AWSNaming.EC2(self, "grafana-instance"),
+            key_name=grafana_key_pair_name,
+            role=grafana_role,
+            security_group=security_group,
+            user_data=ec2.UserData.custom(
+                generate_user_data_script(
+                    region=Stack.of(self).region,
+                    settings_bucket_name=settings_bucket_name,
+                    grafana_admin_secret_name=grafana_admin_secret_name,
+                )
+            ),
+        )
+
+        return grafana_instance

--- a/src/lib/aws/aws_naming.py
+++ b/src/lib/aws/aws_naming.py
@@ -79,6 +79,16 @@ class AWSNaming:
         prefix = "tstable"
         outp = f"{prefix}-{meaning}" # Table lives inside DB, so we identify project and stage names by DB
         return outp
+        
+    @classmethod
+    def EC2(cls, stack_obj: object, meaning: str) -> str:
+        prefix = "ec2"
+        return AWSNaming.__resource_name_with_check(stack_obj, prefix, meaning)
+    
+    @classmethod
+    def SM(cls, stack_obj: object, meaning: str) -> str:
+        prefix = "sm"
+        return AWSNaming.__resource_name_with_check(stack_obj, prefix, meaning)
 
 
     @classmethod

--- a/src/lib/core/grafana_config_generator.py
+++ b/src/lib/core/grafana_config_generator.py
@@ -1,0 +1,84 @@
+import os
+import json
+
+
+def generate_dashboard_model(
+    service, timestream_database_name, timestream_table_name
+) -> dict:
+    """Generates Dashboard json model for each Service"""
+    dashboard_path = os.path.join(
+        "infra_tooling_account", "grafana", "sample_dashboard.json"
+    )
+    with open(dashboard_path) as json_file:
+        dashboard_data = json.load(json_file)
+
+    dashboard_data["title"] = f"Metrics Dashboard for {service}"
+    dashboard_data["panels"][0]["datasource"] = f"Amazon-Timestream-{service}"
+    dashboard_data["panels"][0]["title"] = f"{service}"
+    dashboard_data["panels"][0]["targets"][0][
+        "datasource"
+    ] = f"Amazon-Timestream-{service}"
+    dashboard_data["panels"][0]["targets"][0][
+        "database"
+    ] = f'"{timestream_database_name}"'
+    dashboard_data["panels"][0]["targets"][0]["table"] = f'"{timestream_table_name}"'
+
+    return dashboard_data
+
+
+def generate_datasources_config_section(
+    service, region, timestream_database_name, timestream_table_name
+) -> dict:
+    """Generates Datasource config section for each Service"""
+    return {
+        "name": f"Amazon-Timestream-{service}",
+        "type": "grafana-timestream-datasource",
+        "isDefault": False,
+        "jsonData": {
+            "authType": "default",
+            "defaultRegion": region,
+            "defaultDatabase": f'"{timestream_database_name}"',
+            "defaultTable": f'"{timestream_table_name}"',
+        },
+    }
+
+
+def generate_dashboards_config_section(service) -> dict:
+    """Generates Dashboard config section for each Service"""
+    return {
+        "name": f"{service}_dashboard",
+        "type": "file",
+        "allowUiUpdates": True,
+        "updateIntervalSeconds": 30,
+        "options": {"path": f"data/{service}_dashboard.json"},
+    }
+
+
+def generate_user_data_script(
+    region: str, settings_bucket_name: str, grafana_admin_secret_name: str
+) -> str:
+    """Generates User Data script that should be run at Grafana launch.
+
+    Args:
+        settings_bucket_name (str): Settings S3 Bucket name
+        grafana_admin_secret_name (str): Grafana Secret name
+
+    Returns:
+        str: User data with set of commands
+    """
+    user_data_file_path = os.path.join(
+        "infra_tooling_account", "grafana", "sample_user_data.sh"
+    )
+    with open(user_data_file_path, "r") as user_data_file:
+        user_data_content = user_data_file.read()
+
+    replacements = {
+        "{region}": region,
+        "{settings_bucket_name}": settings_bucket_name,
+        "{grafana_admin_secret_name}": grafana_admin_secret_name,
+    }
+
+    for placeholder, replacement in replacements.items():
+        user_data_content = user_data_content.replace(placeholder, replacement)
+
+    return user_data_content

--- a/src/lib/settings/settings.py
+++ b/src/lib/settings/settings.py
@@ -280,6 +280,32 @@ class Settings:
         return self.processed_settings[SettingFileNames.GENERAL]["tooling_environment"][
             "metrics_collection_interval_min"
         ]
+    
+    def get_grafana_mandatory_settings(self) -> tuple[str, str]:
+        """
+        Get mandatory grafana settings:
+            - grafana_vpc_id: VPC ID for Grafana instance
+            - grafana_security_group_id: Security Group ID for Grafana instance
+        If not provided, the Grafana stack will be skipped.
+        """
+        grafana_settings = self.processed_settings[SettingFileNames.GENERAL]["tooling_environment"]
+        return (
+            grafana_settings.get("grafana_vpc_id"),
+            grafana_settings.get("grafana_security_group_id"))
+
+    def get_grafana_optional_settings(self) -> tuple[str, str, str]:
+        """
+        Get optional grafana settings:
+            - grafana_key_pair_name: Key pair name. if not provided, will be created in the Grafana stack
+            - grafana_image: Bitnami Grafana image. Defaults to "bitnami-grafana-10.2.2-1-r02-linux-debian-11-x86_64-hvm-ebs-nami"
+            - grafana_instance_type: Grafana Instance type. Defaults to "t3.micro"
+        """
+        grafana_settings = self.processed_settings[SettingFileNames.GENERAL]["tooling_environment"]
+        return (
+            grafana_settings.get("grafana_key_pair_name"),
+            grafana_settings.get("grafana_bitnami_image", "bitnami-grafana-10.2.2-1-r02-linux-debian-11-x86_64-hvm-ebs-nami"),
+            grafana_settings.get("grafana_instance_type", "t3.micro"),
+        )
 
     def get_tooling_account_props(self) -> (str, str):
         """Returns account_id and region of tooling environment."""


### PR DESCRIPTION
- optional Grafana stack added (if mandatory configs vpc id and security group id are not provided - this stack will be skipped)
- also some optional configs can be set: grafana_key_pair_name (if not provided, will be created in the Grafana stack), grafana_image (Bitnami Grafana image. Defaults to "bitnami-grafana-10.2.2-1-r02-linux-debian-11-x86_64-hvm-ebs-nami"), grafana_instance_type (Grafana Instance type. Defaults to "t3.micro")
- sample dashboard and user data script added to a separate folder infra_tooling_account/grafana
- Grafana provisioned config files will be generated considering each Service (Glue, Lambda, etc), uploaded to S3 settings bucket and copied to the Grafana instance at launch time. As a result, for each Service, a separate dashboard and data source will be provisioned in Grafana
- after the Stack deployment, to sign in, go to http://<grafana-instance-public-ip>:3000 and login under admin user and password taken from the corresponding Grafana secret created in SM.
