### PR TITLE
Feature/alert events cloudwatch

### DIFF
--- a/src/lambda_alerting.py
+++ b/src/lambda_alerting.py
@@ -57,7 +57,7 @@ def write_event_to_cloudwatch(
     logged_event["event_severity"] = event_severity
 
     logged_event_time = time_utils.iso_time_to_epoch_milliseconds(event["time"])
-    result = publisher.put_event(logged_event_time, json.dumps(logged_event, indent=-4))
+    result = publisher.put_event(logged_event_time, json.dumps(logged_event, indent=4))
 
     logger.info("EventJSON has been written successfully")
     logger.info(result)

--- a/src/lambda_alerting.py
+++ b/src/lambda_alerting.py
@@ -3,41 +3,61 @@ import json
 import boto3
 import logging
 
+from lib.core import time_utils
 from lib.aws.sqs_manager import SQSQueueSender
-from lib.aws.timestream_manager import TimestreamTableWriter
+from lib.aws.cloudwatch_manager import CloudWatchEventsPublisher
 from lib.event_mapper.aws_event_mapper import AwsEventMapper
 from lib.settings import Settings
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
-timestream_write_client = boto3.client("timestream-write")
 sqs_client = boto3.client("sqs")
+cloudwatch_client = boto3.client("logs")
 
 
-def write_event_to_timestream(records):
+def write_event_to_cloudwatch(
+    monitored_env_name: str,
+    resource_name: str,
+    service_name: str,
+    event_severity: str,
+    event: dict,
+):
     """
-    Writes a given list of records to an Amazon Timestream table.
+    Writes a given list of records to an Amazon CloudWatch logs.
 
-    Retrieves the database and table names from environment variables and uses
-    an instance of TimestreamTableWriter to write the provided records to the
-    specified Timestream table.
+    Retrieves the log group and log stream names from environment variables and uses
+    an instance of CloudWatchEventPublisher to write the provided records to the
+    specified CloudWatch log stream.
 
     Args:
-        records (list): A list of records to be written to the Timestream table.
+        monitored_env_name (str): The name of the monitored environment.
+        resource_name (str): The name of the AWS resource.
+        service_name (str): The name of the AWS service.
+        event_severity (str): Severity of the event.
+        event (dict): The event dict to be written to the CloudWatch stream.
 
     Returns:
         None: This function does not return anything but logs the outcome.
     """
-    db_name = os.environ["ALERT_EVENTS_DB_NAME"]
-    table_name = os.environ["ALERT_EVENTS_TABLE_NAME"]
+    log_group_name = os.environ["ALERT_EVENTS_CLOUDWATCH_LOG_GROUP_NAME"]
+    log_stream_name = os.environ["ALERT_EVENTS_CLOUDWATCH_LOG_STREAM_NAME"]
 
-    writer = TimestreamTableWriter(
-        db_name=db_name,
-        table_name=table_name,
-        timestream_write_client=timestream_write_client,
+    publisher = CloudWatchEventsPublisher(
+        log_group_name=log_group_name,
+        log_stream_name=log_stream_name,
+        cloudwatch_client=cloudwatch_client,
     )
-    result = writer.write_records(records=records)
+
+    logged_event = {}
+    logged_event["event"] = event
+    logged_event["monitored_environment"] = monitored_env_name
+    logged_event["resource_name"] = resource_name
+    logged_event["service_name"] = service_name
+    logged_event["event_severity"] = event_severity
+
+    logged_event_time = time_utils.iso_time_to_epoch_milliseconds(event["time"])
+    result = publisher.put_event(logged_event_time, json.dumps(logged_event, indent=-4))
 
     logger.info("EventJSON has been written successfully")
     logger.info(result)
@@ -56,60 +76,6 @@ def send_messages_to_sqs(queue_url: str, messages: list[dict]):
     logger.info(f"Results of sending messages to SQS: {results}")
 
 
-def prepare_timestream_record(monitored_env_name, event):
-    """
-    Prepares a Timestream record from the given event and its properties.
-
-    Formats the event and its properties into the structure required by Timestream,
-    including dimensions and time conversion.
-
-    Args:
-        event_props (dict): The structured properties of the event.
-        event (dict): The original event data.
-
-    Returns:
-        list: A list containing the prepared Timestream record.
-    """
-    records = []
-
-    dimensions = [
-        {
-            "Name": "monitored_environment",
-            "Value": monitored_env_name,
-        },
-        {"Name": "source", "Value": event["source"]},
-    ]
-    record_time = TimestreamTableWriter.iso_time_to_epoch_milliseconds(event["time"])
-
-    records.append(
-        {
-            "Dimensions": dimensions,
-            "MeasureName": "event_json",
-            "MeasureValue": json.dumps(event, indent=4),
-            "MeasureValueType": "VARCHAR",
-            "Time": record_time,
-        }
-    )
-
-    return records
-
-
-def map_to_notification_messages(event_props: dict, settings: Settings) -> list[dict]:
-    """Maps given event object to notification messages array
-
-    Args:
-        event_props (dict): Event object
-        settings (Settings): Settings object
-
-    Returns:
-        list[dict]: List of message objects
-    """
-    mapper = AwsEventMapper(settings)
-    messages = mapper.to_notification_messages(event_props)
-
-    return messages
-
-
 def lambda_handler(event, context):
     logger.info(f"event = {event}")
 
@@ -120,14 +86,20 @@ def lambda_handler(event, context):
         event["account"], event["region"]
     )
 
-    messages = map_to_notification_messages(event, settings)
+    mapper = AwsEventMapper(settings)
+    messages = mapper.to_notification_messages(event)
+
     logger.info(f"Notification messages: {messages}")
 
     queue_url = os.environ["NOTIFICATION_QUEUE_URL"]
     send_messages_to_sqs(queue_url, messages)
 
-    timestream_records = prepare_timestream_record(monitored_env_name, event)
-    write_event_to_timestream(timestream_records)
+    resource_name = mapper.to_resource_name(event)
+    service_name = mapper.to_service_name(event)
+    event_severity = mapper.to_event_severity(event)
+    write_event_to_cloudwatch(
+        monitored_env_name, resource_name, service_name, event_severity, event
+    )
 
     return {"messages": messages}
 

--- a/src/lib/aws/aws_naming.py
+++ b/src/lib/aws/aws_naming.py
@@ -77,9 +77,20 @@ class AWSNaming:
     @classmethod
     def TimestreamTable(cls, stack_obj: object, meaning: str) -> str:
         prefix = "tstable"
-        outp = f"{prefix}-{meaning}" # Table lives inside DB, so we identify project and stage names by DB
+        outp = f"{prefix}-{meaning}"  # Table lives inside DB, so we identify project and stage names by DB
         return outp
 
+    @classmethod
+    def LogGroupName(cls, stack_obj: object, meaning: str) -> str:
+        prefix = "log-group"
+        outp = AWSNaming.__resource_name_with_check(stack_obj, prefix, meaning)
+        return outp
+
+    @classmethod
+    def LogStreamName(cls, stack_obj: object, meaning: str) -> str:
+        prefix = "log-stream"
+        outp = AWSNaming.__resource_name_with_check(stack_obj, prefix, meaning)
+        return outp
 
     @classmethod
     def Arn_IAMRole(cls, stack_obj: object, account_id: str, role_name: str) -> str:

--- a/src/lib/aws/cloudwatch_manager.py
+++ b/src/lib/aws/cloudwatch_manager.py
@@ -1,0 +1,64 @@
+import boto3
+
+
+class CloudWatchEventsPublisherException(Exception):
+    """Exception raised for errors encountered while publishing message to the CloudWatch stream."""
+
+    pass
+
+
+class CloudWatchEventsPublisher:
+    """
+    This class provides an interface to publish messages to a specified Amazon CloudWatch stream.
+    It uses the AWS SDK for Python (Boto3) to interact with the
+    CloudWatch service.
+
+    Attributes:
+        log_group_name (str): The name of the CloudWatch group.
+        log_stream_name (str): The name of the CloudWatch stream.
+        cloudwatch_client: The Boto3 CloudWatch client. If not provided,
+            a new client instance is created.
+
+    Methods:
+        put_event(time, event): Publishes a message to the CloudWatch stream.
+    """
+
+    def __init__(
+        self, log_group_name: str, log_stream_name: str, cloudwatch_client=None
+    ):
+        """
+        Initializes a new CloudWatchEventsPublisher instance.
+
+        Args:
+            log_group_name (str): The name of the CloudWatch group.
+            log_stream_name (str): The name of the CloudWatch stream.
+            cloudwatch_client: The Boto3 CloudWatch client. If not provided,
+                a new client instance is created.
+        """
+        self.log_group_name = log_group_name
+        self.log_stream_name = log_stream_name
+        self.cloudwatch_client = (
+            boto3.client("logs") if cloudwatch_client is None else cloudwatch_client
+        )
+
+    def put_event(self, time: int, event: str):
+        """
+        Publishes a message to the CloudWatch stream.
+
+        Args:
+            time: Event time in epoch milliseconds.
+            event: An event string to be sent to the CloudWatch stream.
+
+        Returns:
+            The response from the CloudWatch put_log_events API calls.
+
+        """
+        try:
+            return self.cloudwatch_client.put_log_events(
+                logGroupName=self.log_group_name,
+                logStreamName=self.log_stream_name,
+                logEvents=[{"timestamp": time, "message": event}],
+            )
+        except Exception as e:
+            error_message = f"Error publishing events to {self.log_group_name} : {self.log_stream_name}: {e}"
+            raise CloudWatchEventsPublisherException(error_message)

--- a/src/lib/aws/timestream_manager.py
+++ b/src/lib/aws/timestream_manager.py
@@ -74,30 +74,6 @@ class TimestreamTableWriter:
             if "ExistingVersion" in rr:
                 print("Rejected record existing version: ", rr["ExistingVersion"])
 
-    @staticmethod
-    def iso_time_to_epoch_milliseconds(iso_date: str) -> str:
-        """
-        Convert an ISO 8601 formatted date string to the number of milliseconds since the Unix epoch.
-        If the input is None, the current time in milliseconds since the Unix epoch is returned.
-
-        Parameters:
-        iso_date (str): An ISO 8601 formatted date string (e.g., "2023-11-21T21:39:09Z").
-                        If None, the current time is used.
-
-        Returns:
-        str: The number of milliseconds since the Unix epoch as a string.
-        """
-
-        # If the input is None, use the current time
-        if iso_date is None:
-            return time_utils.epoch_milliseconds_str()
-        else:
-            # Convert the ISO date string to a datetime object
-            dt = datetime.fromisoformat(iso_date.rstrip("Z"))
-            # Convert the datetime object to epoch time in seconds
-            epoch_time = dt.timestamp()
-            return time_utils.epoch_milliseconds_str(epoch_time)
-
     def _write_batch(self, records, common_attributes={}):
         """
         Writes a single batch (up to 100 records) to the Timestream table.

--- a/src/lib/core/time_utils.py
+++ b/src/lib/core/time_utils.py
@@ -1,0 +1,56 @@
+from datetime import datetime
+import time
+
+
+def epoch_milliseconds(epoch_seconds: float = None) -> int:
+    """
+    Converts epoch time in seconds to a int representation in milliseconds.
+
+    If no argument is provided, the current time is used.
+
+    Args:
+        epoch_seconds (float, optional): The epoch time in seconds. If None,
+                                         the current time is used. Defaults to None.
+
+    Returns:
+        str: The epoch time in milliseconds as an int.
+    """
+    tmp = epoch_seconds if epoch_seconds is not None else time.time()
+    return int(round(tmp * 1000))
+
+
+def datetime_to_epoch_milliseconds(datetime_value: datetime) -> str:
+    """
+    Convert a datetime object to a string representation in milliseconds (which is required to timestream record)
+
+    Parameters:
+    datetime_value (datetime): The datetime object to be converted.
+
+    Returns:
+    str: The datetime object as a string in milliseconds.
+    """
+    return str(epoch_milliseconds(datetime_value.timestamp()))
+
+
+def iso_time_to_epoch_milliseconds(iso_date: str) -> int:
+    """
+    Convert an ISO 8601 formatted date string to the number of milliseconds since the Unix epoch.
+    If the input is None, the current time in milliseconds since the Unix epoch is returned.
+
+    Parameters:
+    iso_date (str): An ISO 8601 formatted date string (e.g., "2023-11-21T21:39:09Z").
+                    If None, the current time is used.
+
+    Returns:
+    str: The number of milliseconds since the Unix epoch as a string.
+    """
+
+    # If the input is None, use the current time
+    if iso_date is None:
+        return epoch_milliseconds()
+    else:
+        # Convert the ISO date string to a datetime object
+        dt = datetime.fromisoformat(iso_date.rstrip("Z"))
+        # Convert the datetime object to epoch time in seconds
+        epoch_time = dt.timestamp()
+        return epoch_milliseconds(epoch_time)

--- a/src/lib/event_mapper/aws_event_mapper.py
+++ b/src/lib/event_mapper/aws_event_mapper.py
@@ -18,6 +18,61 @@ class AwsEventMapper:
             "aws.states": StepFunctionsEventMapper(settings),
         }
 
+    def __get_event_mapper(self, event: dict) -> GeneralAwsEventMapper:
+        """Retrieves event mapper for a provided event.
+
+        Args:
+            event (dict): Event to process
+
+        Raises:
+            EventParsingException: If no mapper is found for the event.
+
+        Returns:
+            GeneralAwsEventMapper: Event mapper with service specific logic.
+        """
+        event_source = event["source"]
+
+        if event_source not in self.event_map:
+            raise EventParsingException(f"No parsing logic for source {event_source}.")
+
+        return self.event_map[event_source]
+
+    def to_resource_name(self, event: dict) -> str:
+        """Retrieves the name of the AWS resource the event is related to.
+
+        Args:
+            event (dict): Event to analyze.
+
+        Returns:
+            str: AWS resource name.
+        """
+        target_mapper = self.__get_event_mapper(event)
+        return target_mapper.get_resource_name(event)
+
+    def to_service_name(self, event: dict) -> str:
+        """Retrieves the name of the AWS service the event is related to.
+
+        Args:
+            event (dict): Event to analyze.
+
+        Returns:
+            str: AWS service name.
+        """
+        target_mapper = self.__get_event_mapper(event)
+        return target_mapper.get_service_name()
+
+    def to_event_severity(self, event: dict) -> str:
+        """Determines the severity of the event.
+
+        Args:
+            event (dict): Event to analyze.
+
+        Returns:
+            str: Event severity.
+        """
+        target_mapper = self.__get_event_mapper(event)
+        return target_mapper.get_event_severity(event)
+
     def to_notification_messages(self, event: dict) -> list[dict]:
         """Maps AWS event object to a list of notification message objects
 
@@ -30,11 +85,6 @@ class AwsEventMapper:
         Returns:
             list[dict]: List of message objects
         """
-        event_source = event["source"]
-
-        if event_source not in self.event_map:
-            raise EventParsingException(f"No parsing logic for source {event_source}.")
-
-        target_mapper: GeneralAwsEventMapper = self.event_map[event_source]
+        target_mapper = self.__get_event_mapper(event)
 
         return target_mapper.to_notification_messages(event)

--- a/src/lib/event_mapper/impl/general_aws_event_mapper.py
+++ b/src/lib/event_mapper/impl/general_aws_event_mapper.py
@@ -21,7 +21,7 @@ class GeneralAwsEventMapper(ABC):
         self.settings = settings
 
     @abstractmethod
-    def get_resource_name(self, event: dict):
+    def get_resource_name(self, event: dict) -> str:
         """Returns name of the AWS resource the given event belongs to (job/stateMachine/function etc.)
 
         Args:
@@ -30,7 +30,21 @@ class GeneralAwsEventMapper(ABC):
         pass
 
     @abstractmethod
-    def get_message_body(self, event: dict):
+    def get_service_name(self) -> str:
+        """Returns name of the AWS service the given event belongs to (Glue/Step Functions/Lambda etc.)"""
+        pass
+
+    @abstractmethod
+    def get_event_severity(self, event: dict) -> str:
+        """Returns the severity of the occurred event
+
+        Args:
+            event (dict): Event object
+        """
+        pass
+
+    @abstractmethod
+    def get_message_body(self, event: dict) -> list[dict]:
         """Returns composed message body for the given AWS event
 
         Args:

--- a/src/lib/event_mapper/impl/glue_event_mapper.py
+++ b/src/lib/event_mapper/impl/glue_event_mapper.py
@@ -9,6 +9,12 @@ class GlueEventMapper(GeneralAwsEventMapper):
     def get_resource_name(self, event):
         return event["detail"]["jobName"]
 
+    def get_service_name(self):
+        return "Glue"
+
+    def get_event_severity(self, event):  # todo: implement
+        return "Unknown"
+
     def get_message_body(self, event):
         message_body = []
         table = {}

--- a/src/lib/event_mapper/impl/step_functions_event_mapper.py
+++ b/src/lib/event_mapper/impl/step_functions_event_mapper.py
@@ -11,6 +11,12 @@ class StepFunctionsEventMapper(GeneralAwsEventMapper):
         arn = event["detail"]["stateMachineArn"]
         return arn.split("stateMachine:")[1]
 
+    def get_service_name(self):
+        return "Step Functions"
+
+    def get_event_severity(self, event):  # todo: implement
+        return "Unknown"
+
     @staticmethod
     def __timestamp_to_datetime(timestamp: int) -> str:
         """Formats integer datetime from the event to the ISO formatted datetime string

--- a/src/lib/metrics_extractor/step_functions_metrics_extractor.py
+++ b/src/lib/metrics_extractor/step_functions_metrics_extractor.py
@@ -1,20 +1,23 @@
 from datetime import datetime
 
 from lib.aws.step_functions_manager import StepFunctionsManager, ExecutionData
-from lib.aws.timestream_manager import TimeStreamQueryRunner,  TimestreamTableWriter
+from lib.aws.timestream_manager import TimeStreamQueryRunner, TimestreamTableWriter
 from lib.metrics_extractor.base_metrics_extractor import BaseMetricsExtractor
+from lib.core import time_utils
 
 
 class StepFunctionsMetricExtractor(BaseMetricsExtractor):
     """
     Class is responsible for extracting glue job metrics
-    """ 
+    """
 
     def get_last_update_time(self, timestream_query_client) -> datetime:
         """
         Get time of this entity's data latest update (we append data since that time only)
         """
-        queryRunner = TimeStreamQueryRunner(timestream_query_client=timestream_query_client)
+        queryRunner = TimeStreamQueryRunner(
+            timestream_query_client=timestream_query_client
+        )
 
         # check if table is empty
         query = f'SELECT count(*) FROM "{self.timestream_db_name}"."{self.timestream_metrics_table_name}"'
@@ -28,11 +31,14 @@ class StepFunctionsMetricExtractor(BaseMetricsExtractor):
 
     def _extract_metrics_data(self, since_time: datetime) -> list[ExecutionData]:
         step_functions_man = StepFunctionsManager(self.aws_service_client)
-        step_function_executions = step_functions_man.get_step_function_executions( step_function_name=self.entity_name, since_time=since_time
+        step_function_executions = step_functions_man.get_step_function_executions(
+            step_function_name=self.entity_name, since_time=since_time
         )
         return step_function_executions
 
-    def _data_to_timestream_records(self, step_function_executions: list[ExecutionData]) -> list:
+    def _data_to_timestream_records(
+        self, step_function_executions: list[ExecutionData]
+    ) -> list:
         common_dimensions = [
             {"Name": "monitored_environment", "Value": self.monitored_environment_name},
             {"Name": "step_function_name", "Value": self.entity_name},
@@ -45,13 +51,18 @@ class StepFunctionsMetricExtractor(BaseMetricsExtractor):
             if StepFunctionsManager.is_final_state(
                 step_function_execution.status
             ):  # exclude writing metrics for executions in progress
-                dimensions = [{"Name": "step_function_run_id", "Value": step_function_execution.name}]
+                dimensions = [
+                    {
+                        "Name": "step_function_run_id",
+                        "Value": step_function_execution.name,
+                    }
+                ]
 
                 metric_values = [
                     ("execution", 1, "BIGINT"),
                     ("succeeded", int(step_function_execution.IsSuccess), "BIGINT"),
                     ("failed", int(step_function_execution.IsFailure), "BIGINT"),
-                    ("duration_sec", step_function_execution.Duration, "DOUBLE")
+                    ("duration_sec", step_function_execution.Duration, "DOUBLE"),
                 ]
                 measure_values = [
                     {
@@ -62,7 +73,7 @@ class StepFunctionsMetricExtractor(BaseMetricsExtractor):
                     for metric_name, metric_value, metric_type in metric_values
                 ]
 
-                record_time = TimestreamTableWriter.datetime_to_epoch_milliseconds(
+                record_time = time_utils.datetime_to_epoch_milliseconds(
                     step_function_execution.startDate
                 )
 
@@ -80,6 +91,7 @@ class StepFunctionsMetricExtractor(BaseMetricsExtractor):
 
     def prepare_metrics_data(self, since_time: datetime) -> (list, dict):
         step_function_executions = self._extract_metrics_data(since_time=since_time)
-        records, common_attributes = self._data_to_timestream_records(step_function_executions)
+        records, common_attributes = self._data_to_timestream_records(
+            step_function_executions
+        )
         return records, common_attributes
-        


### PR DESCRIPTION
Publish alert events to CloudWatch instead of Timestream in Alerting Lambda to avoid the 2048 symbols limitation for MeasureValue.