### PR TITLE
Bug - Settings wildcards

### DIFF
--- a/config/sample_settings/replacements.json
+++ b/config/sample_settings/replacements.json
@@ -1,7 +1,7 @@
 {
-    "env": "dev",
-    "tooling_account_id": "323432554",
-    "sender_email": "salmon-no-reply@soname.de",
-    "grafana_vpc_id": "vpc_id", 
-    "grafana_security_group_id": "security_group_id"
+    "<<env>>": "dev",
+    "<<tooling_account_id>>": "323432554",
+    "<<sender_email>>": "salmon-no-reply@soname.de",
+    "<<grafana_vpc_id>>": "vpc_id", 
+    "<<grafana_security_group_id>>": "security_group_id"
 }

--- a/infra_monitored_account/infra_monitored_account/infra_monitored_stack.py
+++ b/infra_monitored_account/infra_monitored_account/infra_monitored_stack.py
@@ -122,6 +122,8 @@ class InfraMonitoredStack(Stack):
             actions=[
                 "glue:ListJobs",
                 "glue:ListWorkflows",
+                "glue:ListCrawlers",
+                "glue:GetDatabases",
                 "glue:GetJob",
                 "glue:GetJobs",
                 "glue:GetJobRun",

--- a/src/lambda_test_settings.py
+++ b/src/lambda_test_settings.py
@@ -11,6 +11,7 @@ def lambda_handler(event, context):
     settings_s3_path = os.environ["SETTINGS_S3_PATH"]
     iam_role_name = os.environ["IAMROLE_MONITORED_ACC_EXTRACT_METRICS"]
 
+    # settings = Settings.from_file_path(settings_s3_path, iam_role_name)
     settings = Settings.from_s3_path(settings_s3_path, iam_role_name)
 
     job_name = event["detail"]["jobName"]
@@ -36,10 +37,16 @@ def lambda_handler(event, context):
     print(json.dumps(settings.processed_settings, indent=4))
 
     # Check processed monitoring groups (should be used only when needed)
-    print(json.dumps(settings.monitoring_groups, indent=4))
+    print(json.dumps(settings.processed_monitoring_groups, indent=4))
 
 
 if __name__ == "__main__":
+    os.environ[
+        "IAMROLE_MONITORED_ACC_EXTRACT_METRICS"
+    ] = "role-salmon-monitored-acc-extract-metrics-devnp"
+    os.environ["SETTINGS_S3_PATH"] = "s3://s3-salmon-settings-devnp/settings/"
+    # os.environ["SETTINGS_S3_PATH"] = "../config/settings/"
+
     test_event = """
         {
             "version": "0",

--- a/src/lib/aws/glue_manager.py
+++ b/src/lib/aws/glue_manager.py
@@ -142,16 +142,38 @@ class GlueManager:
         except Exception as e:
             raise GlueManagerException(f"Error getting list of glue workflows : {e}")
 
+    def _get_all_crawler_names(self):
+        try:
+            response = self.glue_client.list_crawlers()
+            return response.get("CrawlerNames")
+
+        except Exception as e:
+            raise GlueManagerException(f"Error getting list of glue crawlers : {e}")
+
+    def _get_all_data_catalog_names(self):
+        try:
+            response = self.glue_client.get_databases()
+            return [res["Name"] for res in response.get("DatabaseList")]
+
+        except Exception as e:
+            raise GlueManagerException(
+                f"Error getting list of glue data catalogs : {e}"
+            )
+
     def get_all_names(self, **kwargs):
         resource_type = kwargs.pop("resource_type", None)
         if (
-            # default behavior to return jobs list
+            # default behavior is to return jobs list
             resource_type is None
             or resource_type == SettingConfigResourceTypes.GLUE_JOBS
         ):
             return self._get_all_job_names()
         elif resource_type == SettingConfigResourceTypes.GLUE_WORKFLOWS:
             return self._get_all_workflow_names()
+        elif resource_type == SettingConfigResourceTypes.GLUE_CRAWLERS:
+            return self._get_all_crawler_names()
+        elif resource_type == SettingConfigResourceTypes.GLUE_DATA_CATALOGS:
+            return self._get_all_data_catalog_names()
         else:
             raise GlueManagerException(f"Unknown glue resource type {resource_type}")
 

--- a/src/lib/core/json_utils.py
+++ b/src/lib/core/json_utils.py
@@ -43,8 +43,9 @@ def replace_values_in_json(json_data: json, replacements: dict) -> dict:
         elif isinstance(obj, list):
             for i, item in enumerate(obj):
                 obj[i] = replace_recursive(item)
-        elif isinstance(obj, str) and obj in replacements:
-            obj = replacements[obj]
+        elif isinstance(obj, str):
+            for key, value in replacements.items():
+                obj = obj.replace(key, value)
         return obj
 
     return replace_recursive(json_data)


### PR DESCRIPTION
Issues fixed:

1. Wildcards replacement works as expected for all monitoring groups (issue was that monitoring group dictionary changes while looping through it - some entries were lost)
2. _nested_replace_placeholders() replaced with unified method replace_values_in_json() from json_utils
3. Added logic to retrieve Glue Crawlers and Data Catalogs list for wildcards replacements