### PR TITLE
extract metrics lambda started throwing error when calling glue.GetJobRuns

### DIFF
--- a/src/lib/aws/glue_manager.py
+++ b/src/lib/aws/glue_manager.py
@@ -16,7 +16,7 @@ class JobRun(BaseModel):
     # TriggerName: str
     JobName: str
     StartedOn: datetime
-    LastModifiedOn: datetime
+    LastModifiedOn: Optional[datetime]
     CompletedOn: Optional[datetime]
     JobRunState: str
     ErrorMessage: Optional[str] = None


### PR DESCRIPTION
extract metrics lambda were throwing error: validation error for JobRunsData\nJobRuns -> 2 -> LastModifiedOn\n  field required

it started, I believe, after glue job recreation in testing stand, so LastModifiedOn was no longer populated. Fixed. It's an optional field indeed