### PR TITLE
SQS type changed to FIFO

### DIFF
--- a/infra_tooling_account/infra_tooling_account/infra_tooling_common_stack.py
+++ b/infra_tooling_account/infra_tooling_account/infra_tooling_common_stack.py
@@ -130,7 +130,7 @@ class InfraToolingCommonStack(Stack):
             export_name=AWSNaming.CfnOutput(self, "internal-error-topic-arn"),
         )
 
-    def create_timestream_db(self) -> (timestream.CfnDatabase, kms.Key):
+    def create_timestream_db(self) -> tuple[timestream.CfnDatabase, kms.Key]:
         """Creates Timestream database for events and metrics
 
         Returns:

--- a/infra_tooling_account/infra_tooling_account/infra_tooling_common_stack.py
+++ b/infra_tooling_account/infra_tooling_account/infra_tooling_common_stack.py
@@ -72,6 +72,8 @@ class InfraToolingCommonStack(Stack):
         notification_queue = sqs.Queue(
             self,
             "salmonNotificationQueue",
+            content_based_deduplication=True,
+            fifo=True,
             queue_name=AWSNaming.SQSQueue(self, "notification"),
             visibility_timeout=Duration.seconds(60),
         )

--- a/infra_tooling_account/infra_tooling_account/infra_tooling_common_stack.py
+++ b/infra_tooling_account/infra_tooling_account/infra_tooling_common_stack.py
@@ -71,7 +71,7 @@ class InfraToolingCommonStack(Stack):
         # TODO: confirm visibility timeout
         notification_queue = sqs.Queue(
             self,
-            "salmonNotificationQueue",
+            "salmonNotificationFIFOQueue",
             content_based_deduplication=True,
             fifo=True,
             queue_name=AWSNaming.SQSQueue(self, "notification"),
@@ -118,7 +118,7 @@ class InfraToolingCommonStack(Stack):
             self,
             "salmonNotificationQueueArn",
             value=notification_queue.queue_arn,
-            description="The ARN of the Notification SQS Queue",
+            description="The ARN of the Notification FIFO SQS Queue",
             export_name=AWSNaming.CfnOutput(self, "notification-queue-arn"),
         )
 
@@ -185,7 +185,7 @@ class InfraToolingCommonStack(Stack):
 
         Args:
             internal_error_topic (sns.Topic): SNS Topic for DLQ alerts
-            notification_queue (sqs.Queue): SQS queue as the input for notification lambda
+            notification_queue (sqs.Queue): FIFO SQS queue as the input for notification lambda
 
         Returns:
             lambda_.Function: Notification Lambda

--- a/infra_tooling_account/infra_tooling_account/infra_tooling_common_stack.py
+++ b/infra_tooling_account/infra_tooling_account/infra_tooling_common_stack.py
@@ -67,11 +67,11 @@ class InfraToolingCommonStack(Stack):
             topic_name=AWSNaming.SNSTopic(self, "internal-error"),
         )
 
-        # Notification SQS Queue
+        # Notification FIFO SQS Queue
         # TODO: confirm visibility timeout
         notification_queue = sqs.Queue(
             self,
-            "salmonNotificationFIFOQueue",
+            "salmonNotificationQueue",
             content_based_deduplication=True,
             fifo=True,
             queue_name=AWSNaming.SQSQueue(self, "notification"),
@@ -118,7 +118,7 @@ class InfraToolingCommonStack(Stack):
             self,
             "salmonNotificationQueueArn",
             value=notification_queue.queue_arn,
-            description="The ARN of the Notification FIFO SQS Queue",
+            description="The ARN of the Notification SQS Queue",
             export_name=AWSNaming.CfnOutput(self, "notification-queue-arn"),
         )
 
@@ -185,7 +185,7 @@ class InfraToolingCommonStack(Stack):
 
         Args:
             internal_error_topic (sns.Topic): SNS Topic for DLQ alerts
-            notification_queue (sqs.Queue): FIFO SQS queue as the input for notification lambda
+            notification_queue (sqs.Queue): SQS queue as the input for notification lambda
 
         Returns:
             lambda_.Function: Notification Lambda

--- a/src/lambda_alerting.py
+++ b/src/lambda_alerting.py
@@ -6,7 +6,7 @@ from lib.aws.sqs_manager import SQSQueueSender
 from lib.event_mapper.event_mapper_provider import EventMapperProvider
 from lib.event_mapper.resource_type_resolver import ResourceTypeResolver
 from lib.settings import Settings
-from lib.core.constants import EventResult, NotificationType
+from lib.core.constants import EventResult
 from lib.alerting_service import DeliveryOptionsResolver, CloudWatchAlertWriter
 
 logger = logging.getLogger()
@@ -79,7 +79,7 @@ def lambda_handler(event, context):
         queue_url = os.environ["NOTIFICATION_QUEUE_URL"]
         send_messages_to_sqs(
             queue_url=queue_url,
-            message_group_id=NotificationType.ALERT,
+            message_group_id=resource_name,
             messages=notification_messages,
         )
 

--- a/src/lambda_digest.py
+++ b/src/lambda_digest.py
@@ -136,13 +136,14 @@ def distribute_digest_report(
             message_body = message_builder.generate_message_body(
                 digest_start_time, digest_end_time
             )
+            message_subject = f"Digest Report {datetime.now(tz=timezone.utc).strftime('%Y-%m-%d')}"
             message = {
                 "delivery_options": {
                     "recipients": recipients_group["recipients"],
                     "delivery_method": recipients_group["delivery_method"],
                 },
                 "message": {
-                    "message_subject": f"Digest Report {datetime.now(tz=timezone.utc).strftime('%Y-%m-%d')}",
+                    "message_subject": message_subject,
                     "message_body": message_body,
                 },
             }
@@ -150,7 +151,7 @@ def distribute_digest_report(
             # send the messages to FIFO queue
             sender = SQSQueueSender(
                 queue_url=notification_queue_url,
-                message_group_id=NotificationType.DIGEST,
+                message_group_id=recipients_group,
                 sqs_client=sqs_client,
             )
             results = sender.send_messages(messages=[message])

--- a/src/lambda_digest.py
+++ b/src/lambda_digest.py
@@ -136,14 +136,14 @@ def distribute_digest_report(
             message_body = message_builder.generate_message_body(
                 digest_start_time, digest_end_time
             )
-            message_date = datetime.now(tz=timezone.utc).strftime('%Y-%m-%d')
+            message_subject = f"Digest Report {datetime.now(tz=timezone.utc).strftime('%Y-%m-%d')}"
             message = {
                 "delivery_options": {
                     "recipients": recipients_group["recipients"],
                     "delivery_method": recipients_group["delivery_method"],
                 },
                 "message": {
-                    "message_subject": f"Digest Report {message_date}",
+                    "message_subject": message_subject,
                     "message_body": message_body,
                 },
             }
@@ -151,7 +151,7 @@ def distribute_digest_report(
             # send the messages to FIFO queue
             sender = SQSQueueSender(
                 queue_url=notification_queue_url,
-                message_group_id=f"{message_date}_group_{i}",
+                message_group_id=f"digest_group_{i}",
                 sqs_client=sqs_client,
             )
             results = sender.send_messages(messages=[message])

--- a/src/lambda_digest.py
+++ b/src/lambda_digest.py
@@ -146,8 +146,14 @@ def distribute_digest_report(
                     "message_body": message_body,
                 },
             }
-            sender = SQSQueueSender(notification_queue_url, sqs_client)
-            results = sender.send_messages([message])
+
+            # send the messages to FIFO queue
+            sender = SQSQueueSender(
+                queue_url=notification_queue_url,
+                message_group_id=NotificationType.DIGEST,
+                sqs_client=sqs_client,
+            )
+            results = sender.send_messages(messages=[message])
 
             logger.info(
                 f"Results of sending messages to SQS: {results} for the recipient group: {recipients_group['recipients']}"
@@ -223,15 +229,15 @@ if __name__ == "__main__":
 
     os.environ[
         "IAMROLE_MONITORED_ACC_EXTRACT_METRICS"
-    ] = "role-salmon-monitored-acc-extract-metrics-devay"
+    ] = "role-salmon-monitored-acc-extract-metrics-{stage_name}"
     os.environ[
         "TIMESTREAM_METRICS_DB_NAME"
-    ] = "timestream-salmon-metrics-events-storage-devay"
-    os.environ["SETTINGS_S3_PATH"] = "s3://s3-salmon-settings-devay/settings/"
+    ] = "timestream-salmon-metrics-events-storage-{stage_name}"
+    os.environ["SETTINGS_S3_PATH"] = "s3://s3-salmon-settings-{stage_name}/settings/"
     os.environ["DIGEST_REPORT_PERIOD_HOURS"] = "24"
     os.environ[
         "NOTIFICATION_QUEUE_URL"
-    ] = "https://sqs.{region}.amazonaws.com/{account_id}/queue-salmon-notification-devay"
+    ] = "https://sqs.{region}.amazonaws.com/{account_id}/queue-salmon-notification-{stage_name}.fifo"
 
     event = {}
     lambda_handler(event, None)

--- a/src/lambda_digest.py
+++ b/src/lambda_digest.py
@@ -122,7 +122,7 @@ def distribute_digest_report(
 ):
     logger.info("Distributing the digest report to the relevant recipients")
 
-    for recipients_group in recipients_groups:
+    for i, recipients_group in enumerate(recipients_groups):
         # get relevant digest data
         recipients_group_data = [
             item
@@ -136,14 +136,14 @@ def distribute_digest_report(
             message_body = message_builder.generate_message_body(
                 digest_start_time, digest_end_time
             )
-            message_subject = f"Digest Report {datetime.now(tz=timezone.utc).strftime('%Y-%m-%d')}"
+            message_date = datetime.now(tz=timezone.utc).strftime('%Y-%m-%d')
             message = {
                 "delivery_options": {
                     "recipients": recipients_group["recipients"],
                     "delivery_method": recipients_group["delivery_method"],
                 },
                 "message": {
-                    "message_subject": message_subject,
+                    "message_subject": f"Digest Report {message_date}",
                     "message_body": message_body,
                 },
             }
@@ -151,7 +151,7 @@ def distribute_digest_report(
             # send the messages to FIFO queue
             sender = SQSQueueSender(
                 queue_url=notification_queue_url,
-                message_group_id=recipients_group,
+                message_group_id=f"{message_date}_group_{i}",
                 sqs_client=sqs_client,
             )
             results = sender.send_messages(messages=[message])

--- a/src/lib/aws/aws_naming.py
+++ b/src/lib/aws/aws_naming.py
@@ -67,7 +67,8 @@ class AWSNaming:
     @classmethod
     def SQSQueue(cls, stack_obj: object, meaning: str) -> str:
         prefix = "queue"
-        return AWSNaming.__resource_name_with_check(stack_obj, prefix, meaning)
+        ending = ".fifo" # FIFO queue names must end in '.fifo'
+        return AWSNaming.__resource_name_with_check(stack_obj, prefix, meaning) + ending
 
     @classmethod
     def TimestreamDB(cls, stack_obj: object, meaning: str) -> str:
@@ -79,13 +80,13 @@ class AWSNaming:
         prefix = "tstable"
         outp = f"{prefix}-{meaning}"  # Table lives inside DB, so we identify project and stage names by DB
         return outp
-    
+
     @classmethod
     def TimestreamMetricsTable(cls, stack_obj: object, resource_type: str) -> str:
-        ### 
+        ###
         meaning = f"{resource_type}-metrics"
         return AWSNaming.TimestreamTable(stack_obj, meaning)
-        
+
     @classmethod
     def EC2(cls, stack_obj: object, meaning: str) -> str:
         prefix = "ec2"

--- a/src/lib/aws/sqs_manager.py
+++ b/src/lib/aws/sqs_manager.py
@@ -16,8 +16,8 @@ class SQSQueueSender:
 
     Attributes:
         queue_url (str): The url of the SQS queue.
-        message_group_id (str): The tag that specifies that
-            a message belongs to a specific message group
+        message_group_id (str): The tag that specifies that a message belongs to
+            a specific message group. The max length is 128 characters.
         sqs_client: The Boto3 SQS client. If not provided,
             a new client instance is created.
 
@@ -31,13 +31,13 @@ class SQSQueueSender:
 
         Args:
             queue_url (str): The url of the SQS queue.
-            message_group_id (str): The tag that specifies that
-                a message belongs to a specific message group
+            message_group_id (str): The tag that specifies that a message belongs to
+                a specific message group. The max length is 128 characters.
             sqs_client: The Boto3 SQS client. If not provided,
                 a new client instance is created.
         """
         self.queue_url = queue_url
-        self.message_group_id = message_group_id
+        self.message_group_id = message_group_id[:128]
         self.sqs_client = boto3.client("sqs") if sqs_client is None else sqs_client
 
     def send_messages(self, messages: list[dict]):

--- a/src/lib/aws/sqs_manager.py
+++ b/src/lib/aws/sqs_manager.py
@@ -16,6 +16,8 @@ class SQSQueueSender:
 
     Attributes:
         queue_url (str): The url of the SQS queue.
+        message_group_id (str): The tag that specifies that
+            a message belongs to a specific message group
         sqs_client: The Boto3 SQS client. If not provided,
             a new client instance is created.
 
@@ -23,16 +25,19 @@ class SQSQueueSender:
         send_message(message): Sends a message to the SQS queue.
     """
 
-    def __init__(self, queue_url: str, sqs_client=None):
+    def __init__(self, queue_url: str, message_group_id: str, sqs_client=None):
         """
         Initializes a new SQSQueueSender instance.
 
         Args:
             queue_url (str): The url of the SQS queue.
+            message_group_id (str): The tag that specifies that
+                a message belongs to a specific message group
             sqs_client: The Boto3 SQS client. If not provided,
                 a new client instance is created.
         """
         self.queue_url = queue_url
+        self.message_group_id = message_group_id
         self.sqs_client = boto3.client("sqs") if sqs_client is None else sqs_client
 
     def send_messages(self, messages: list[dict]):
@@ -52,6 +57,7 @@ class SQSQueueSender:
                 result = self.sqs_client.send_message(
                     QueueUrl=self.queue_url,
                     MessageBody=json.dumps(message, indent=4),
+                    MessageGroupId=self.message_group_id,
                 )
                 results.append(result)
             except Exception as e:


### PR DESCRIPTION
- SQS type changed to FIFO 
- content_based_deduplication enabled*. If we don't enable content-based deduplication and want to deduplicate messages, we would need to provide an explicit deduplication ID in our SendMessage() call. 
https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues-moving.html

*taking into account that we send messages with unique message bodies

- MessageGroupId attribute added to SQSQueueSender. FIFO queue logic applies only per message group ID. Each message group ID represents a distinct ordered message group within an Amazon SQS queue. For each message group ID, all messages are sent and received in strict order. However, messages with different message group ID values might be sent and received out of order. There is no quota to the number of message groups within a FIFO queue.

https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues-understanding-logic.html
https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagegroupid-property.html

- FIFO queue names must end in '.fifo'


![image](https://github.com/Soname-Solutions/salmon/assets/150046345/27fb4a51-ac5b-4879-a629-0d13cbd2f888)
