### PR TITLE
dashboards provisioned to default folder

### DIFF
--- a/infra_tooling_account/infra_tooling_account/grafana/glue_workflows_dashboard.template.json
+++ b/infra_tooling_account/infra_tooling_account/grafana/glue_workflows_dashboard.template.json
@@ -172,7 +172,7 @@
           "database": "<<DATABASE_NAME>>",
           "datasource": "Amazon-Timestream",
           "measure": "execution",
-          "rawQuery": "SELECT  time, ${measure:csv} FROM $__database.$__table where $__timeFilter ",
+          "rawQuery": "SELECT  time, ${measure:csv} FROM $__database.$__table where $__timeFilter and resource_name in (${resource_name:singlequote}) and monitored_environment in (${monitored_env:singlequote})",
           "refId": "A",
           "table": "<<DATABASE_TABLE>>"
         }

--- a/infra_tooling_account/infra_tooling_account/grafana/lambda_functions_dashboard.template.json
+++ b/infra_tooling_account/infra_tooling_account/grafana/lambda_functions_dashboard.template.json
@@ -196,7 +196,7 @@
           "database": "<<DATABASE_NAME>>",
           "datasource": "Amazon-Timestream",
           "measure": "execution",
-          "rawQuery": "SELECT time, ${measure:csv} FROM $__database.$__table where $__timeFilter ",
+          "rawQuery": "SELECT time, ${measure:csv} FROM $__database.$__table where $__timeFilter and resource_name in (${resource_name:singlequote}) and monitored_environment in (${monitored_env:singlequote})",
           "refId": "A",
           "table": "<<DATABASE_TABLE>>"
         }

--- a/infra_tooling_account/infra_tooling_account/grafana/step_functions_dashboard.template.json
+++ b/infra_tooling_account/infra_tooling_account/grafana/step_functions_dashboard.template.json
@@ -172,7 +172,7 @@
           "database": "<<DATABASE_NAME>>",
           "datasource": "Amazon-Timestream",
           "measure": "execution",
-          "rawQuery": "SELECT time, ${measure:csv} FROM $__database.$__table where $__timeFilter ",
+          "rawQuery": "SELECT time, ${measure:csv} FROM $__database.$__table where $__timeFilter and resource_name in (${resource_name:singlequote}) and monitored_environment in (${monitored_env:singlequote})",
           "refId": "A",
           "table": "<<DATABASE_TABLE>>"
         }

--- a/src/lib/core/grafana_config_generator.py
+++ b/src/lib/core/grafana_config_generator.py
@@ -58,7 +58,9 @@ def generate_timestream_dashboard_model(
         with open(dashboard_path) as json_file:
             json_data = json.load(json_file)
     except FileNotFoundError:
-        logger.warning(f"Dashboard file for {resource_type} not found: {dashboard_path}. Skipping.")
+        logger.warning(
+            f"Dashboard file for {resource_type} not found: {dashboard_path}. Skipping."
+        )
         return None
 
     replacements = {
@@ -120,11 +122,14 @@ def generate_dashboards_config(resource_types: list) -> dict:
     dashboards_sections = []
     for resource_type in resource_types:
         dashboard_path = os.path.join(
-        "infra_tooling_account", "grafana", f"{resource_type}_dashboard.template.json"
+            "infra_tooling_account",
+            "grafana",
+            f"{resource_type}_dashboard.template.json",
         )
         if os.path.exists(dashboard_path):
             dashboard_section = {
                 "name": f"{resource_type}_dashboard",
+                "folder": "default",
                 "type": "file",
                 "allowUiUpdates": True,
                 "updateIntervalSeconds": 30,
@@ -134,6 +139,7 @@ def generate_dashboards_config(resource_types: list) -> dict:
 
     cw_dashboard_section = {
         "name": "cw_dashboard",
+        "folder": "default",
         "type": "file",
         "allowUiUpdates": True,
         "updateIntervalSeconds": 30,

--- a/src/lib/core/grafana_config_generator.py
+++ b/src/lib/core/grafana_config_generator.py
@@ -129,7 +129,7 @@ def generate_dashboards_config(resource_types: list) -> dict:
         if os.path.exists(dashboard_path):
             dashboard_section = {
                 "name": f"{resource_type}_dashboard",
-                "folder": "default",
+                "folder": "Default SALMON Dashboards",
                 "type": "file",
                 "allowUiUpdates": True,
                 "updateIntervalSeconds": 30,
@@ -139,7 +139,7 @@ def generate_dashboards_config(resource_types: list) -> dict:
 
     cw_dashboard_section = {
         "name": "cw_dashboard",
-        "folder": "default",
+        "folder": "Default SALMON Dashboards",
         "type": "file",
         "allowUiUpdates": True,
         "updateIntervalSeconds": 30,


### PR DESCRIPTION
- all Grafana dashboards will be provisioned in a separate folder "Default SALMON Dashboards" 
![image](https://github.com/Soname-Solutions/salmon/assets/150046345/46784953-3f76-4aae-a9b8-935e690d88e3)


- the condition added to the query to be able to update the graphs based on the resource and monitored env names selected on the dashboards