### PR TITLE
Bugfix/gw add error message

### DIFF
--- a/infra_monitored_account/infra_monitored_account/infra_monitored_stack.py
+++ b/infra_monitored_account/infra_monitored_account/infra_monitored_stack.py
@@ -140,6 +140,7 @@ class InfraMonitoredStack(Stack):
                 "glue:GetJobRun",
                 "glue:GetJobRuns",
                 "glue:GetWorkflowRuns",
+                "glue:GetWorkflowRun",
             ],
             resources=["*"],
             effect=iam.Effect.ALLOW,

--- a/src/lib/metrics_extractor/glue_workflows_metrics_extractor.py
+++ b/src/lib/metrics_extractor/glue_workflows_metrics_extractor.py
@@ -42,8 +42,9 @@ class GlueWorkflowsMetricExtractor(BaseMetricsExtractor):
                 # If ErrorMessage is not returned for the failed Glue workflow run,
                 # generate an error message based on all failed components that belong to the workflow
                 if workflow_run.IsFailure and workflow_run_error_message is None:
+                    glue_man = GlueManager(super().get_aws_service_client())
                     workflow_run_error_message = (
-                        GlueManager.generate_workflow_run_error_message(
+                        glue_man.generate_workflow_run_error_message(
                             workflow_name=workflow_run.Name,
                             workflow_run_id=workflow_run.WorkflowRunId,
                         )


### PR DESCRIPTION
-  If workflow_run.ErrorMessage* is None for the failed Glue workflow run, an error message will be generated based on all failed components that belong to the workflow graph

*Currently the only error message is "Concurrent runs exceeded for workflow: foo." --> https://docs.aws.amazon.com/glue/latest/webapi/API_WorkflowRun.html 

- each error message will be limited to 50 characters and the final error message - to 100 characters
- if more then one error message, the prefix f"Total Errors: {error_count}. " will be added to the final message

- an example from the database:

![image](https://github.com/Soname-Solutions/salmon/assets/150046345/9c52b155-55bc-44dd-8d44-4105bc34364f)
