### PR TITLE
fixes for smtp

### DIFF
--- a/config/sample_settings/general.json
+++ b/config/sample_settings/general.json
@@ -34,7 +34,8 @@
             "name": "local_smtp",
             "delivery_method_type": "SMTP",
             "sender_email": "<<sender_email>>",
-            "credentials_secret_name": "sm-my-smtp-server-creds"
+            "credentials_secret_name": "sm-my-smtp-server-creds",
+            "use_ssl": true
         },
         {
             "name": "sns_main",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 * Unit test code coverage improved to ~90%
 * Notifications
   * Added AWS_SNS delivery method type
+  * Added SMTP delivery method type
 
 ## 1.0.0
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -147,7 +147,7 @@ Based on the delivery method type, additional parameters are required:
 * SMTP:
     - `sender_email` - the sender email for notifications and digests.
     - `credentials_secret_name` - The name of the secret stored in AWS Secrets Manager containing the SMTP server credentials. Required key-value pairs: `SMTP_SERVER`, `SMTP_PORT`, `SMTP_LOGIN`, `SMTP_PASSWORD`.
-    - (optional) `use_ssl` - indicate whether to use SSL for the SMTP server connection. If set to True, the connection will use SSL. Otherwhise STARTTLS will be used. Default value: `True`.
+    - (optional) `use_ssl` - indicate whether to use SSL for the SMTP server connection. If set to True, the connection will use SSL. Otherwhise, STARTTLS will be used. Default value: `True`.
     - (optional) `timeout` -  the connection timeout in seconds. Default value: `10.0`.
 
 You can specify multiple delivery methods (even for the same delivery type, no restrictions).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -147,13 +147,13 @@ Based on the delivery method type, additional parameters are required:
 * SMTP:
     - `sender_email` - the sender email for notifications and digests.
     - `credentials_secret_name` - the name of the secret stored in AWS Secrets Manager containing the SMTP server credentials. Required key-value pairs: SMTP_SERVER, SMTP_PORT, SMTP_LOGIN, SMTP_PASSWORD. \
-    Example JSON structure of the secret:
+    Sample JSON context of the secret:
     ``` json
        {
          "SMTP_SERVER": "put_smtp_host_here",
          "SMTP_PORT": "put_smtp_port_here",
          "SMTP_LOGIN": "put_smtp_login_here",
-         "SMTP_PASSWORD": "put_smtp_password_here",
+         "SMTP_PASSWORD": "put_smtp_password_here"
         }
     ```
     - (optional) `use_ssl` - indicate whether to use SSL for the SMTP server connection. If set to True, the connection will use SSL. Otherwhise, STARTTLS will be used. Default value: `True`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,7 +146,7 @@ Based on the delivery method type, additional parameters are required:
     - No additional parameters needed. Target SNS topic Arn is configured in recipients section.
 * SMTP:
     - `sender_email` - the sender email for notifications and digests.
-    - `credentials_secret_name` - The name of the secret stored in AWS Secrets Manager containing the SMTP server credentials. Required key-value pairs: `SMTP_SERVER`, `SMTP_PORT`, `SMTP_LOGIN`, `SMTP_PASSWORD`.
+    - `credentials_secret_name` - the name of the secret stored in AWS Secrets Manager containing the SMTP server credentials. Required key-value pairs: `SMTP_SERVER`, `SMTP_PORT`, `SMTP_LOGIN`, `SMTP_PASSWORD`.
     - (optional) `use_ssl` - indicate whether to use SSL for the SMTP server connection. If set to True, the connection will use SSL. Otherwhise, STARTTLS will be used. Default value: `True`.
     - (optional) `timeout` -  the connection timeout in seconds. Default value: `10.0`.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,7 +146,16 @@ Based on the delivery method type, additional parameters are required:
     - No additional parameters needed. Target SNS topic Arn is configured in recipients section.
 * SMTP:
     - `sender_email` - the sender email for notifications and digests.
-    - `credentials_secret_name` - the name of the secret stored in AWS Secrets Manager containing the SMTP server credentials. Required key-value pairs: `SMTP_SERVER`, `SMTP_PORT`, `SMTP_LOGIN`, `SMTP_PASSWORD`.
+    - `credentials_secret_name` - the name of the secret stored in AWS Secrets Manager containing the SMTP server credentials. Required key-value pairs: SMTP_SERVER, SMTP_PORT, SMTP_LOGIN, SMTP_PASSWORD. \
+    Example JSON structure of the secret:
+    ``` json
+       {
+         "SMTP_SERVER": "put_smtp_host_here",
+         "SMTP_PORT": "put_smtp_port_here",
+         "SMTP_LOGIN": "put_smtp_login_here",
+         "SMTP_PASSWORD": "put_smtp_password_here",
+        }
+    ```
     - (optional) `use_ssl` - indicate whether to use SSL for the SMTP server connection. If set to True, the connection will use SSL. Otherwhise, STARTTLS will be used. Default value: `True`.
     - (optional) `timeout` -  the connection timeout in seconds. Default value: `10.0`.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -144,6 +144,11 @@ Based on the delivery method type, additional parameters are required:
     - `sender_email` - the sender email for notifications and digests. Must be verified in AWS SES.
 * AWS_SNS:
     - No additional parameters needed. Target SNS topic Arn is configured in recipients section.
+* SMTP:
+    - `sender_email` - the sender email for notifications and digests.
+    - `credentials_secret_name` - The name of the secret stored in AWS Secrets Manager containing the SMTP server credentials. Required key-value pairs: `SMTP_SERVER`, `SMTP_PORT`, `SMTP_LOGIN`, `SMTP_PASSWORD`.
+    - (optional) `use_ssl` - indicate whether to use SSL for the SMTP server connection. If set to True, the connection will use SSL. Otherwhise STARTTLS will be used. Default value: `True`.
+    - (optional) `timeout` -  the connection timeout in seconds. Default value: `10.0`.
 
 You can specify multiple delivery methods (even for the same delivery type, no restrictions).
 

--- a/infra_tooling_account/infra_tooling_account/infra_tooling_common_stack.py
+++ b/infra_tooling_account/infra_tooling_account/infra_tooling_common_stack.py
@@ -220,7 +220,9 @@ class InfraToolingCommonStack(NestedStack):
             iam.PolicyStatement(
                 actions=["sns:Publish"],
                 effect=iam.Effect.ALLOW,
-                resources=["*"] # referring to '*' instead of internal_error_topic.topic_arn as there might be SNS way of regular 
+                resources=[
+                    "*"
+                ]  # referring to '*' instead of internal_error_topic.topic_arn as there might be SNS way of regular
                 # notification configured, so need to publish to arbitrary topics.
             )
         )
@@ -246,6 +248,16 @@ class InfraToolingCommonStack(NestedStack):
                 ],
                 effect=iam.Effect.ALLOW,
                 resources=[internal_error_topic.topic_arn],
+            )
+        )
+
+        notification_lambda_role.add_to_policy(
+            iam.PolicyStatement(
+                actions=["secretsmanager:GetSecretValue"],
+                effect=iam.Effect.ALLOW,
+                resources=[
+                    "*"
+                ],  # to be able to retrieve Secrets required for SMTP sender
             )
         )
 

--- a/src/lib/notification_service/sender/smtp.py
+++ b/src/lib/notification_service/sender/smtp.py
@@ -80,11 +80,11 @@ class SmtpSender(Sender):
         with SMTP_SSL(
             host=smtp_server, port=port, timeout=self._timeout, context=context
         ) as server:
-            server.login(login, password)
+            server.login(user=login, password=password)
             server.sendmail(
-                self._sender_email,
-                self._recipients,
-                self._get_message().as_string(),
+                from_addr=self._sender_email,
+                to_addrs=self._recipients,
+                msg=self._get_message().as_string(),
             )
 
     def _send_via_starttls(
@@ -98,11 +98,11 @@ class SmtpSender(Sender):
         """Send email via SMTP STARTTLS."""
         with SMTP(host=smtp_server, port=port, timeout=self._timeout) as server:
             server.starttls(context=context)
-            server.login(login, password)
+            server.login(user=login, password=password)
             server.sendmail(
-                self._sender_email,
-                self._recipients,
-                self._get_message().as_string(),
+                from_addr=self._sender_email,
+                to_addrs=self._recipients,
+                msg=self._get_message().as_string(),
             )
 
     def send(self) -> None:
@@ -113,14 +113,14 @@ class SmtpSender(Sender):
         if smtp_secret_name is None:
             raise KeyError("Credentials Secret Name is not set.")
 
-        smtp_secret = self._secret_client.get_secret(smtp_secret_name)
+        smtp_secret = self._secret_client.get_secret(secret_name=smtp_secret_name)
         smtp_server = self._get_smtp_credential_property(smtp_secret, "SMTP_SERVER")
         port = int(self._get_smtp_credential_property(smtp_secret, "SMTP_PORT"))
         login = self._get_smtp_credential_property(smtp_secret, "SMTP_LOGIN")
         password = self._get_smtp_credential_property(smtp_secret, "SMTP_PASSWORD")
 
         try:
-            if self._use_ssl:
+            if self._use_ssl and port != 25:
                 self._send_via_ssl(smtp_server, port, login, password, context)
             else:
                 self._send_via_starttls(smtp_server, port, login, password, context)

--- a/src/lib/notification_service/sender/smtp.py
+++ b/src/lib/notification_service/sender/smtp.py
@@ -3,7 +3,6 @@ from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from smtplib import SMTP_SSL, SMTPResponseException
-import json
 import ssl
 
 from typing import List
@@ -31,7 +30,7 @@ class SmtpSender(Sender):
         message = MIMEMultipart("mixed")
         message_body = MIMEMultipart("alternative")
 
-        message["Subject"] = self._message.header
+        message["Subject"] = self._message.subject
         message["From"] = self._delivery_method.get("sender_email")
         message["To"] = ",".join(self._recipients)
 
@@ -74,7 +73,7 @@ class SmtpSender(Sender):
         if smtp_secret_name is None:
             raise KeyError("Credentials Secret Name is not set.")
 
-        smtp_secret = json.loads(self._secret_client.get_secret(smtp_secret_name))
+        smtp_secret = self._secret_client.get_secret(smtp_secret_name)
         smtp_server = self._get_smtp_credential_property(smtp_secret, "SMTP_SERVER")
         port = self._get_smtp_credential_property(smtp_secret, "SMTP_PORT")
         login = self._get_smtp_credential_property(smtp_secret, "SMTP_LOGIN")

--- a/src/lib/notification_service/sender/smtp.py
+++ b/src/lib/notification_service/sender/smtp.py
@@ -2,7 +2,7 @@ from email.message import Message as BaseEmailMessage
 from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-from smtplib import SMTP_SSL, SMTPResponseException
+from smtplib import SMTP, SMTP_SSL, SMTPResponseException
 import ssl
 
 from typing import List
@@ -22,6 +22,9 @@ class SmtpSender(Sender):
         """Initiate class EmailSender."""
         super().__init__(delivery_method, message, recipients)
         self._secret_client = SecretManager()
+        self._sender_email = self._delivery_method.get("sender_email")
+        self._use_ssl = self._delivery_method.get("use_ssl", True)
+        self._timeout = self._delivery_method.get("timeout", 10.0)
 
     def _get_message(self) -> BaseEmailMessage:
         """Get message to send."""
@@ -31,7 +34,7 @@ class SmtpSender(Sender):
         message_body = MIMEMultipart("alternative")
 
         message["Subject"] = self._message.subject
-        message["From"] = self._delivery_method.get("sender_email")
+        message["From"] = self._sender_email
         message["To"] = ",".join(self._recipients)
 
         # Encode the text and HTML content and set the character encoding. This step is
@@ -65,6 +68,43 @@ class SmtpSender(Sender):
         mime_object.add_header("Content-Disposition", "attachment", filename=file.name)
         return mime_object
 
+    def _send_via_ssl(
+        self,
+        smtp_server: str,
+        port: int,
+        login: str,
+        password: str,
+        context: ssl.SSLContext,
+    ) -> None:
+        """Send email via SMTP SSL."""
+        with SMTP_SSL(
+            host=smtp_server, port=port, timeout=self._timeout, context=context
+        ) as server:
+            server.login(login, password)
+            server.sendmail(
+                self._sender_email,
+                self._recipients,
+                self._get_message().as_string(),
+            )
+
+    def _send_via_starttls(
+        self,
+        smtp_server: str,
+        port: int,
+        login: str,
+        password: str,
+        context: ssl.SSLContext,
+    ) -> None:
+        """Send email via SMTP STARTTLS."""
+        with SMTP(host=smtp_server, port=port, timeout=self._timeout) as server:
+            server.starttls(context=context)
+            server.login(login, password)
+            server.sendmail(
+                self._sender_email,
+                self._recipients,
+                self._get_message().as_string(),
+            )
+
     def send(self) -> None:
         """Send a message via SMTP."""
         context = ssl.create_default_context()
@@ -75,20 +115,17 @@ class SmtpSender(Sender):
 
         smtp_secret = self._secret_client.get_secret(smtp_secret_name)
         smtp_server = self._get_smtp_credential_property(smtp_secret, "SMTP_SERVER")
-        port = self._get_smtp_credential_property(smtp_secret, "SMTP_PORT")
+        port = int(self._get_smtp_credential_property(smtp_secret, "SMTP_PORT"))
         login = self._get_smtp_credential_property(smtp_secret, "SMTP_LOGIN")
         password = self._get_smtp_credential_property(smtp_secret, "SMTP_PASSWORD")
 
-        with SMTP_SSL(smtp_server, port, context=context) as server:
-            try:
-                server.login(login, password)
-                server.sendmail(
-                    self._delivery_method.get("sender_email"),
-                    self._recipients,
-                    self._get_message().as_string(),
-                )
-            except SMTPResponseException as ex:
-                raise SmtpSenderException(
-                    f"Error during sending message to {self._recipients} "
-                    f"by {self.__class__.__name__}: {str(ex)}."
-                ) from ex
+        try:
+            if self._use_ssl:
+                self._send_via_ssl(smtp_server, port, login, password, context)
+            else:
+                self._send_via_starttls(smtp_server, port, login, password, context)
+        except SMTPResponseException as ex:
+            raise SmtpSenderException(
+                f"Error during sending message to {self._recipients} "
+                f"by {self.__class__.__name__}: {str(ex)}."
+            ) from ex

--- a/src/lib/settings/cdk/schemas/general.json
+++ b/src/lib/settings/cdk/schemas/general.json
@@ -45,7 +45,8 @@
             "name": {"type": "string"},
             "delivery_method_type": {"type": "string"},
             "sender_email": {"type": "string"},
-            "credentials_secret_name": {"type": "string"}
+            "credentials_secret_name": {"type": "string"},
+            "use_ssl":  {"type": "boolean"}
           },
           "required": ["name", "delivery_method_type"]
         }

--- a/src/lib/settings/cdk/schemas/general.json
+++ b/src/lib/settings/cdk/schemas/general.json
@@ -47,7 +47,7 @@
             "sender_email": {"type": "string"},
             "credentials_secret_name": {"type": "string"},
             "use_ssl": {"type": "boolean"},
-            "timeout": {"type": "float"}
+            "timeout": {"type": "number"}
           },
           "required": ["name", "delivery_method_type"]
         }

--- a/src/lib/settings/cdk/schemas/general.json
+++ b/src/lib/settings/cdk/schemas/general.json
@@ -46,7 +46,8 @@
             "delivery_method_type": {"type": "string"},
             "sender_email": {"type": "string"},
             "credentials_secret_name": {"type": "string"},
-            "use_ssl":  {"type": "boolean"}
+            "use_ssl": {"type": "boolean"},
+            "timeout": {"type": "float"}
           },
           "required": ["name", "delivery_method_type"]
         }

--- a/tests/src/lib/notification_service/sender/test_smtp.py
+++ b/tests/src/lib/notification_service/sender/test_smtp.py
@@ -1,0 +1,183 @@
+import pytest
+from unittest.mock import patch
+from smtplib import SMTPResponseException
+
+from lib.aws.secret_manager import SecretManager
+from lib.core.constants import DeliveryMethodTypes
+from lib.notification_service.sender import SmtpSender
+from lib.notification_service.messages import Message, File
+from lib.notification_service.exceptions import SmtpSenderException
+
+TEST_SECRET_NAME = "test-smtp-server-creds"
+TEST_SECRET = {
+    "SMTP_SERVER": "test_server",
+    "SMTP_PORT": 111,
+    "SMTP_LOGIN": "test_login",
+    "SMTP_PASSWORD": "test_password",
+}
+TEST_RECIPIENTS = ["email1@company.com", "email2@company.com"]
+TEST_MSG_SUBJECT = "test_subject"
+TEST_MSG_BODY = "test_message_body"
+TEST_DELIVERY_METHOD = {
+    "name": "smtp",
+    "delivery_method_type": DeliveryMethodTypes.SMTP,
+    "sender_email": "test_sender_email",
+    "credentials_secret_name": TEST_SECRET_NAME,
+}
+
+
+@patch.object(SecretManager, "get_secret", return_value=TEST_SECRET)
+@patch("lib.notification_service.sender.smtp.SMTP_SSL")
+@patch("ssl.create_default_context")
+def test_smtp_send_via_ssl(mock_ssl_context, mock_smtp_ssl, mock_get_secret):
+    # by default, SSL enabled
+    # mock the SSL context, SMTP_SSL instance
+    mock_ssl_instance = mock_ssl_context.return_value
+    mock_smtp_server_instance = mock_smtp_ssl.return_value.__enter__.return_value
+
+    message = Message(subject=TEST_MSG_SUBJECT, body=TEST_MSG_BODY)
+    sender = SmtpSender(
+        delivery_method=TEST_DELIVERY_METHOD,
+        message=message,
+        recipients=TEST_RECIPIENTS,
+    )
+    sender.pre_process()
+    sender.send()
+    # no return values from function, so we are testing successful completion only
+
+    # assert get_secret call
+    mock_get_secret.assert_called_once_with(
+        secret_name=TEST_DELIVERY_METHOD["credentials_secret_name"]
+    )
+    # assert SMTP_SSL call
+    mock_smtp_ssl.assert_called_once_with(
+        host=TEST_SECRET["SMTP_SERVER"],
+        port=TEST_SECRET["SMTP_PORT"],
+        timeout=10.0,
+        context=mock_ssl_instance,
+    )
+    # assert SMTP_SSL login call
+    mock_smtp_server_instance.login.assert_called_once_with(
+        user=TEST_SECRET["SMTP_LOGIN"], password=TEST_SECRET["SMTP_PASSWORD"]
+    )
+    # assert SMTP_SSL sendmail call
+    sendmail_args = mock_smtp_server_instance.sendmail.call_args[1]
+    assert sendmail_args["from_addr"] == TEST_DELIVERY_METHOD["sender_email"]
+    assert sendmail_args["to_addrs"] == TEST_RECIPIENTS
+    assert f"Subject: {TEST_MSG_SUBJECT}" in sendmail_args["msg"]
+
+
+@patch.object(SecretManager, "get_secret", return_value=TEST_SECRET)
+@patch("lib.notification_service.sender.smtp.SMTP")
+@patch("ssl.create_default_context")
+def test_smtp_send_via_starttls(
+    mock_starttls_context, mock_smtp_starttls, mock_get_secret
+):
+    # SSL disabled, so STARTTLS will be used
+    TEST_DELIVERY_METHOD["use_ssl"] = False
+
+    # mock the SSL context, SMTP instance
+    mock_starttls_instance = mock_starttls_context.return_value
+    mock_smtp_server_instance = mock_smtp_starttls.return_value.__enter__.return_value
+
+    message = Message(subject=TEST_MSG_SUBJECT, body=TEST_MSG_BODY)
+    sender = SmtpSender(
+        delivery_method=TEST_DELIVERY_METHOD,
+        message=message,
+        recipients=TEST_RECIPIENTS,
+    )
+    sender.pre_process()
+    sender.send()
+    # no return values from function, so we are testing successful completion only
+
+    # assert get_secret call
+    mock_get_secret.assert_called_once_with(
+        secret_name=TEST_DELIVERY_METHOD["credentials_secret_name"]
+    )
+    # assert SMTP call
+    mock_smtp_starttls.assert_called_once_with(
+        host=TEST_SECRET["SMTP_SERVER"],
+        port=TEST_SECRET["SMTP_PORT"],
+        timeout=10.0,
+    )
+    # assert SMTP starttls call
+    mock_smtp_server_instance.starttls.assert_called_once_with(
+        context=mock_starttls_instance
+    ),
+    # assert SMTP login call
+    mock_smtp_server_instance.login.assert_called_once_with(
+        user=TEST_SECRET["SMTP_LOGIN"], password=TEST_SECRET["SMTP_PASSWORD"]
+    )
+    # assert SMTP sendmail call
+    sendmail_args = mock_smtp_server_instance.sendmail.call_args[1]
+    assert sendmail_args["from_addr"] == TEST_DELIVERY_METHOD["sender_email"]
+    assert sendmail_args["to_addrs"] == TEST_RECIPIENTS
+    assert f"Subject: {TEST_MSG_SUBJECT}" in sendmail_args["msg"]
+
+
+@patch.object(SecretManager, "get_secret", return_value=TEST_SECRET)
+@patch("lib.notification_service.sender.smtp.SMTP")
+@patch("ssl.create_default_context")
+def test_smtp_send_with_file(
+    mock_starttls_context, mock_smtp_starttls, mock_get_secret
+):
+    message = Message(
+        subject=TEST_MSG_SUBJECT,
+        body=TEST_MSG_BODY,
+        file=File(name="attach.txt", content="test content"),
+    )
+    sender = SmtpSender(
+        delivery_method=TEST_DELIVERY_METHOD,
+        message=message,
+        recipients=TEST_RECIPIENTS,
+    )
+    sender.pre_process()
+    sender.send()
+    # no return values from function, so we are testing successful completion only
+
+
+@patch.object(SecretManager, "get_secret", return_value=TEST_SECRET)
+@patch("lib.notification_service.sender.smtp.SMTP")
+@patch("ssl.create_default_context")
+def test_smtp_error_while_sending(
+    mock_starttls_context, mock_smtp_starttls, mock_get_secret
+):
+    mock_smtp_server_instance = mock_smtp_starttls.return_value.__enter__.return_value
+    mock_smtp_server_instance.sendmail.side_effect = SMTPResponseException(
+        code=111, msg="test exception"
+    )
+
+    message = Message(subject=TEST_MSG_SUBJECT, body=TEST_MSG_BODY)
+    sender = SmtpSender(
+        delivery_method=TEST_DELIVERY_METHOD,
+        message=message,
+        recipients=TEST_RECIPIENTS,
+    )
+    with pytest.raises(SmtpSenderException):
+        sender.pre_process()
+        sender.send()
+
+
+@patch.object(SecretManager, "get_secret", return_value=TEST_SECRET)
+@patch("lib.notification_service.sender.smtp.SMTP")
+@patch("ssl.create_default_context")
+def test_smtp_sender_key_error(
+    mock_starttls_context, mock_smtp_starttls, mock_get_secret
+):
+    message = Message(subject=TEST_MSG_SUBJECT, body=TEST_MSG_BODY)
+    sender = SmtpSender(
+        delivery_method=TEST_DELIVERY_METHOD,
+        message=message,
+        recipients=TEST_RECIPIENTS,
+    )
+    TEST_SECRET["SMTP_PORT"] = None
+    with pytest.raises(
+        KeyError, match="SMTP property SMTP_PORT is not defined in the secret"
+    ):
+        sender.pre_process()
+        sender.send()
+
+    TEST_DELIVERY_METHOD["credentials_secret_name"] = None
+    with pytest.raises(KeyError, match="Credentials Secret Name is not set."):
+        sender.pre_process()
+        sender.send()


### PR DESCRIPTION
- new optional params for smtp delivery method: "use_ssl" (enabled by default), "timeout" (10.0 seconds by default)

- tests:

![image](https://github.com/Soname-Solutions/salmon/assets/150046345/fa878a58-e676-4205-b39b-3a3ded516a07)

- full code coverage:

![image](https://github.com/Soname-Solutions/salmon/assets/150046345/d5bc6205-3bc4-4e0f-bbd9-2309463d959c)


testing done for STARTTLS option using "smtp.gmail.com" host and 587 port:
![image](https://github.com/Soname-Solutions/salmon/assets/150046345/50f2b0db-9981-4b3a-ae5f-9e8a7a05a8b9)

