### PR TITLE
Feature/consider tags in iam policies

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -154,8 +154,9 @@ Based on the delivery method type, additional parameters are required:
             "SMTP_PORT": "put_smtp_port_here",
             "SMTP_LOGIN": "put_smtp_login_here",
             "SMTP_PASSWORD": "put_smtp_password_here"
-            }
+        }
         ```
+        > **NOTE:**
         >  The secret in AWS Secrets Manager should have a tag with the key `salmon` and any value. This is required to limit access to only the secrets tagged with `salmon`. 
     - (optional) `use_ssl` - indicate whether to use SSL for the SMTP server connection. If set to True, the connection will use SSL. Otherwhise, STARTTLS will be used. Default value: `True`.
     - (optional) `timeout` -  the connection timeout in seconds. Default value: `10.0`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -148,14 +148,15 @@ Based on the delivery method type, additional parameters are required:
     - `sender_email` - the sender email for notifications and digests.
     - `credentials_secret_name` - the name of the secret stored in AWS Secrets Manager containing the SMTP server credentials. Required key-value pairs: SMTP_SERVER, SMTP_PORT, SMTP_LOGIN, SMTP_PASSWORD. \
     Sample JSON context of the secret:
-    ``` json
-       {
-         "SMTP_SERVER": "put_smtp_host_here",
-         "SMTP_PORT": "put_smtp_port_here",
-         "SMTP_LOGIN": "put_smtp_login_here",
-         "SMTP_PASSWORD": "put_smtp_password_here"
-        }
-    ```
+        ``` json
+        {
+            "SMTP_SERVER": "put_smtp_host_here",
+            "SMTP_PORT": "put_smtp_port_here",
+            "SMTP_LOGIN": "put_smtp_login_here",
+            "SMTP_PASSWORD": "put_smtp_password_here"
+            }
+        ```
+        >  The secret in AWS Secrets Manager should have a tag with the key `salmon` and any value. This is required to limit access to only the secrets tagged with `salmon`. 
     - (optional) `use_ssl` - indicate whether to use SSL for the SMTP server connection. If set to True, the connection will use SSL. Otherwhise, STARTTLS will be used. Default value: `True`.
     - (optional) `timeout` -  the connection timeout in seconds. Default value: `10.0`.
 

--- a/infra_tooling_account/infra_tooling_account/infra_tooling_common_stack.py
+++ b/infra_tooling_account/infra_tooling_account/infra_tooling_common_stack.py
@@ -175,7 +175,7 @@ class InfraToolingCommonStack(NestedStack):
                 effect=iam.Effect.ALLOW,
                 resources=[
                     "*"
-                ]  # referring to '*' instead of internal_error_topic.topic_arn as there might be SNS way of regular
+                ],  # referring to '*' instead of internal_error_topic.topic_arn as there might be SNS way of regular
                 # notification configured, so need to publish to arbitrary topics.
             )
         )
@@ -207,10 +207,13 @@ class InfraToolingCommonStack(NestedStack):
         notification_lambda_role.add_to_policy(
             iam.PolicyStatement(
                 actions=["secretsmanager:GetSecretValue"],
+                conditions={
+                    "StringLike": {f"aws:ResourceTag/{self.project_name}": "*"}
+                },
                 effect=iam.Effect.ALLOW,
                 resources=[
                     "*"
-                ],  # to be able to retrieve Secrets required for SMTP sender
+                ],  # to be able to retrieve Secrets tagged with "salmon" required for SMTP sender
             )
         )
 


### PR DESCRIPTION
- action "secretsmanager:GetSecretValue" limited to only the secrets tagged with "salmon" key