### PR TITLE
prepare configuration for integrational auto-tests

### DIFF
--- a/config/sample_settings/README.md
+++ b/config/sample_settings/README.md
@@ -9,7 +9,7 @@ Contains the following parts:
 
 ### Tooling environment
 
-- metrics_collection_interval_min - interval (in minutes) for extracting metrics from monitored environments
+- metrics_collection_cron_expression - the cron schedule for triggering the metrics extraction process. 
 - digest_report_period_hours - indicates how many recent hours should be covered in the daily digest report. Defaults to 24 hours. 
 - digest_cron_expression: the cron schedule to trigger the daily digest report. Defaults to "cron(0 8 * * ? *)", every day at 8am UTC.
 

--- a/config/sample_settings/general.json
+++ b/config/sample_settings/general.json
@@ -3,7 +3,7 @@
         "name": "Tooling Account [<<env>>]",
         "account_id": "<<tooling_account_id>>",
         "region": "eu-central-1",
-        "metrics_collection_interval_min": 5,
+        "metrics_collection_cron_expression": "cron(*/5 * * * ? *)",
         "digest_report_period_hours" : 24, 
         "digest_cron_expression": "cron(0 8 * * ? *)",
         "grafana_instance": {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,7 +71,7 @@ The `general.json` configuration file sets up the tooling environment, monitored
         "name": "Tooling Account [<<env>>]",
         "account_id": "<<tooling_account_id>>",
         "region": "eu-central-1",
-        "metrics_collection_interval_min": 5,
+        "metrics_collection_cron_expression": "cron(*/5 * * * ? *)",
         "digest_report_period_hours" : 24, 
         "digest_cron_expression": "cron(0 8 * * ? *)",
         "grafana_instance": {
@@ -103,7 +103,7 @@ The `general.json` configuration file sets up the tooling environment, monitored
 
     > Here, `<<env>>` acts as a placeholder that represents the environment name. This allows you to specify a generic name for the tooling account while keeping the option to customize it based on the environment. To define the actual values for placeholders, you can use the replacements.json file (refer to [Configure Replacements for Placeholders](#configure-replacements-for-placeholders)). This file serves as a mapping between placeholders and their corresponding values.
 - `account_id`, `region` - AWS region and account ID for the Tooling environment.
-- `metrics_collection_interval_min` - an interval (in minutes) for extracting metrics from Monitored environments.
+- `metrics_collection_cron_expression` - the cron schedule to trigger metrics extraction from Monitored environments.
 - `digest_report_period_hours` - how many recent hours should be covered in the Daily Digest report. Default value: `24` hours.
 - `digest_cron_expression` - the cron schedule to trigger the Daily Digest report. Default value: `cron(0 8 * * ? *)`, every day at 8am UTC.
 

--- a/infra_tooling_account/infra_tooling_account/infra_tooling_monitoring_stack.py
+++ b/infra_tooling_account/infra_tooling_account/infra_tooling_monitoring_stack.py
@@ -121,16 +121,14 @@ class InfraToolingMonitoringStack(NestedStack):
             timestream_database_name=input_timestream_database_name
         )
 
-        metrics_collection_interval_min = (
-            self.settings.get_metrics_collection_interval_min()
+        metrics_collection_cron_expression = (
+            self.settings.get_metrics_collection_cron_expression()
         )
 
         rule = events.Rule(
             self,
             "MetricsExtractionScheduleRule",
-            schedule=events.Schedule.rate(
-                Duration.minutes(metrics_collection_interval_min)
-            ),
+            schedule=events.Schedule.expression(metrics_collection_cron_expression),
             rule_name=AWSNaming.EventBusRule(self, "metrics-extract-cron"),
         )
         rule.add_target(targets.LambdaFunction(extract_metrics_orch_lambda))

--- a/src/lib/settings/cdk/schemas/general.json
+++ b/src/lib/settings/cdk/schemas/general.json
@@ -7,7 +7,7 @@
           "name": {"type": "string"},
           "account_id": {"type": "string"},
           "region": {"type": "string"},
-          "metrics_collection_interval_min": {"type": "integer"},
+          "metrics_collection_cron_expression": {"type": "string"},
           "digest_report_period_hours": {"type": "integer"},
           "digest_cron_expression": {"type": "string"},
           "grafana_instance": {
@@ -22,7 +22,7 @@
             "required": ["grafana_vpc_id", "grafana_security_group_id"]
           }
         },
-        "required": ["name", "account_id", "region", "metrics_collection_interval_min"]
+        "required": ["name", "account_id", "region", "metrics_collection_cron_expression"]
       },
       "monitored_environments": {
         "type": "array",

--- a/src/lib/settings/settings.py
+++ b/src/lib/settings/settings.py
@@ -69,7 +69,7 @@ class Settings:
         ---
         get_monitored_account_ids: Get monitored account IDs.
         get_monitored_account_region_pairs: Get monitored account IDs and Regions.
-        get_metrics_collection_interval_min: Get metrics collection interval.
+        get_metrics_collection_cron_expression: Get metrics collection cron schedule.
         get_tooling_account_props: Returns account_id and region of the tooling environment.
         get_digest_report_settings: Returns Digest report period (hours) and cron schedule.
         get_grafana_settings: Returns Grafana related settings.
@@ -310,10 +310,10 @@ class Settings:
 
         return monitored_account_region_pairs
 
-    def get_metrics_collection_interval_min(self) -> int:
-        """Get metrics_collection_interval_min"""
+    def get_metrics_collection_cron_expression(self) -> int:
+        """Get metrics_collection_cron_expression"""
         return self.processed_settings[SettingFileNames.GENERAL]["tooling_environment"][
-            "metrics_collection_interval_min"
+            "metrics_collection_cron_expression"
         ]
 
     def get_digest_report_settings(self) -> tuple[int, str]:

--- a/tests/devci_settings/general.json
+++ b/tests/devci_settings/general.json
@@ -4,7 +4,7 @@
         "account_id": "<<main_account_id>>",
         "region": "eu-central-1",
         "digest_report_period_hours" : 72, 
-        "metrics_collection_interval_min" : 15
+        "metrics_collection_cron_expression": "cron(*/5 * * * ? 2199)"
     },
     "monitored_environments": [    
         {

--- a/tests/src/lib/settings/test_configs/config1/general.json
+++ b/tests/src/lib/settings/test_configs/config1/general.json
@@ -3,7 +3,7 @@
         "name": "Tooling Account [<<env>>]",
         "account_id": "<<tooling_account_id>>",
         "region": "us-east-1",
-        "metrics_collection_interval_min": 10,
+        "metrics_collection_cron_expression": "cron(*/5 * * * ? 2199)",
         "digest_report_period_hours" : 48, 
         "digest_cron_expression": "cron(5 8 * * ? *)",
         "grafana_instance": {

--- a/tests/src/lib/settings/test_configs/config10_bad_json_schema_dup_envs/general.json
+++ b/tests/src/lib/settings/test_configs/config10_bad_json_schema_dup_envs/general.json
@@ -3,7 +3,7 @@
         "name": "Tooling Account [dev]",
         "account_id": "1234567890",
         "region": "us-east-1",
-        "metrics_collection_interval_min": 10,
+        "metrics_collection_cron_expression": "cron(*/5 * * * ? 2199)",
         "digest_report_period_hours" : 48, 
         "digest_cron_expression": "cron(5 8 * * ? *)",
         "grafana_instance": {

--- a/tests/src/lib/settings/test_configs/config2_wildcards/general.json
+++ b/tests/src/lib/settings/test_configs/config2_wildcards/general.json
@@ -3,7 +3,7 @@
         "name": "Tooling Account [<<env>>]",
         "account_id": "<<tooling_account_id>>",
         "region": "us-east-1",
-        "metrics_collection_interval_min": 5,
+        "metrics_collection_cron_expression": "cron(*/5 * * * ? 2199)",
         "digest_report_period_hours" : 24, 
         "digest_cron_expression": "cron(0 8 * * ? *)",
         "grafana_instance": {

--- a/tests/src/lib/settings/test_configs/config3_tooling_optional_props_omitted/general.json
+++ b/tests/src/lib/settings/test_configs/config3_tooling_optional_props_omitted/general.json
@@ -3,7 +3,7 @@
         "name": "Tooling Account [<<env>>]",
         "account_id": "<<tooling_account_id>>",
         "region": "us-east-1",
-        "metrics_collection_interval_min": 5
+        "metrics_collection_cron_expression": "cron(*/5 * * * ? 2199)"
     },
     "monitored_environments": [
         {

--- a/tests/src/lib/settings/test_configs/config4_many_groups/general.json
+++ b/tests/src/lib/settings/test_configs/config4_many_groups/general.json
@@ -3,7 +3,7 @@
         "name": "Tooling Account [<<env>>]",
         "account_id": "<<tooling_account_id>>",
         "region": "us-east-1",
-        "metrics_collection_interval_min": 5,
+        "metrics_collection_cron_expression": "cron(*/5 * * * ? 2199)",
         "digest_report_period_hours" : 24, 
         "digest_cron_expression": "cron(0 8 * * ? *)",
         "grafana_instance": {

--- a/tests/src/lib/settings/test_configs/config5_many_recipients/general.json
+++ b/tests/src/lib/settings/test_configs/config5_many_recipients/general.json
@@ -3,7 +3,7 @@
         "name": "Tooling Account [<<env>>]",
         "account_id": "<<tooling_account_id>>",
         "region": "us-east-1",
-        "metrics_collection_interval_min": 5,
+        "metrics_collection_cron_expression": "cron(*/5 * * * ? 2199)",
         "digest_report_period_hours" : 24, 
         "digest_cron_expression": "cron(0 8 * * ? *)",
         "grafana_instance": {

--- a/tests/src/lib/settings/test_configs/config6_no_replacements_file/general.json
+++ b/tests/src/lib/settings/test_configs/config6_no_replacements_file/general.json
@@ -3,7 +3,7 @@
         "name": "Tooling Account [dev]",
         "account_id": "1234567890",
         "region": "us-east-1",
-        "metrics_collection_interval_min": 10,
+        "metrics_collection_cron_expression": "cron(*/5 * * * ? 2199)",
         "digest_report_period_hours" : 48, 
         "digest_cron_expression": "cron(5 8 * * ? *)",
         "grafana_instance": {

--- a/tests/src/lib/settings/test_configs/config7_missing_recipients_file/general.json
+++ b/tests/src/lib/settings/test_configs/config7_missing_recipients_file/general.json
@@ -3,7 +3,7 @@
         "name": "Tooling Account [dev]",
         "account_id": "1234567890",
         "region": "us-east-1",
-        "metrics_collection_interval_min": 10,
+        "metrics_collection_cron_expression": "cron(*/5 * * * ? 2199)",
         "digest_report_period_hours" : 48, 
         "digest_cron_expression": "cron(5 8 * * ? *)",
         "grafana_instance": {

--- a/tests/src/lib/settings/test_configs/config8_bad_json/general.json
+++ b/tests/src/lib/settings/test_configs/config8_bad_json/general.json
@@ -3,7 +3,7 @@
         "name": "Tooling Account [dev]",
         "account_id": "1234567890",
         "region": "us-east-1",
-        "metrics_collection_interval_min": 10,
+        "metrics_collection_cron_expression": "cron(*/5 * * * ? 2199)",
         "digest_report_period_hours" : 48, 
         "digest_cron_expression": "cron(5 8 * * ? *)",
         "grafana_instance": {

--- a/tests/src/lib/settings/test_configs/config9_bad_json_schema/general.json
+++ b/tests/src/lib/settings/test_configs/config9_bad_json_schema/general.json
@@ -4,7 +4,7 @@
         "name": "Tooling Account [dev]",
         "account_id": "1234567890",
         "region": "us-east-1",
-        "metrics_collection_interval_min": 10,
+        "metrics_collection_cron_expression": "cron(*/5 * * * ? 2199)",
         "digest_report_period_hours" : 48, 
         "digest_cron_expression": "cron(5 8 * * ? *)",
         "grafana_instance": {

--- a/tests/src/lib/settings/test_settings.py
+++ b/tests/src/lib/settings/test_settings.py
@@ -126,7 +126,7 @@ def test_getting_tooling_env_props_when_explicitly_defined():
 
     # in general -> tooling env we have (all defined EXPLICITLY, not using defaul values)
     expected_values = {
-        "metrics_collection_interval_min": 10,
+        "metrics_collection_cron_expression": "cron(*/5 * * * ? 2199)",
         "digest_report_period_hours": 48,
         "digest_cron_expression": "cron(5 8 * * ? *)",
         "grafana_instance": {
@@ -135,7 +135,7 @@ def test_getting_tooling_env_props_when_explicitly_defined():
         },
     }
 
-    metrics_collection_interval_min = settings.get_metrics_collection_interval_min()
+    metrics_collection_cron_expression = settings.get_metrics_collection_cron_expression()
     (
         digest_report_period_hours,
         digest_cron_expression,
@@ -149,8 +149,8 @@ def test_getting_tooling_env_props_when_explicitly_defined():
     ) = settings.get_grafana_settings()
 
     assert (
-        metrics_collection_interval_min
-        == expected_values["metrics_collection_interval_min"]
+        metrics_collection_cron_expression
+        == expected_values["metrics_collection_cron_expression"]
     )
     assert digest_report_period_hours == expected_values["digest_report_period_hours"]
     assert digest_cron_expression == expected_values["digest_cron_expression"]
@@ -171,12 +171,12 @@ def test_getting_tooling_env_props_when_omitted():
 
     # in general -> tooling env we have (all defined EXPLICITLY, not using defaul values)
     expected_values = {
-        "metrics_collection_interval_min": 5,  # this one is mandatory anyway
+        "metrics_collection_cron_expression": "cron(*/5 * * * ? 2199)",
         "digest_report_period_hours": DigestSettings.REPORT_PERIOD_HOURS,
         "digest_cron_expression": DigestSettings.CRON_EXPRESSION,
     }
 
-    metrics_collection_interval_min = settings.get_metrics_collection_interval_min()
+    metrics_collection_cron_expression = settings.get_metrics_collection_cron_expression()
     (
         digest_report_period_hours,
         digest_cron_expression,
@@ -184,8 +184,8 @@ def test_getting_tooling_env_props_when_omitted():
     grafana_settings = settings.get_grafana_settings()
 
     assert (
-        metrics_collection_interval_min
-        == expected_values["metrics_collection_interval_min"]
+        metrics_collection_cron_expression
+        == expected_values["metrics_collection_cron_expression"]
     )
     assert digest_report_period_hours == expected_values["digest_report_period_hours"]
     assert digest_cron_expression == expected_values["digest_cron_expression"]


### PR DESCRIPTION
Changing config, so we can avoid triggering processes such as metrics collection and digest generation on schedule.

Metrics collection schedule is now configured by param named "metrics_collection_cron_expression" (previously it was "metrics_collection_interval_min").

So both processes are triggered by cron expression.
For those expressions we can set up something like "cron(*/5 * * * ? 2099)" (year = 2099) in auto-test env configuration, to make sure the processes are not triggered on schedule.