### PR TITLE
Added GitHub actions service user

### DIFF
--- a/.github/workflows/integration_tests_execute.yml
+++ b/.github/workflows/integration_tests_execute.yml
@@ -9,7 +9,9 @@ env:
     STAGE_NAME: devit
     SETTING_FOLDER_NAME: "integration_tests/settings"
 run-name: integration tests - execute tests
-on: [workflow_dispatch]
+on: 
+  workflow_dispatch:
+  repository_dispatch:
 jobs:
   integration-testing:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration_tests_execute.yml
+++ b/.github/workflows/integration_tests_execute.yml
@@ -11,7 +11,7 @@ env:
 run-name: integration tests - execute tests
 on: 
   workflow_dispatch:
-  repository_dispatch:
+  workflow_call:
 jobs:
   integration-testing:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration_tests_execute.yml
+++ b/.github/workflows/integration_tests_execute.yml
@@ -2,7 +2,6 @@ name: Integration tests - Execute Tests
 env:
     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}  # temp for testing
     AWS_DEFAULT_REGION: 'eu-central-1'
     CDK_INTEGRATION_TESTS_FOLDER: integration_tests/cdk
     CDK_TOOLING_ENV_FOLDER: infra_tooling_account

--- a/.github/workflows/integration_tests_full.yml
+++ b/.github/workflows/integration_tests_full.yml
@@ -14,10 +14,8 @@ env:
 run-name: integration tests - full
 on: [workflow_dispatch]
 jobs:
-    stub:
+    full-integration-tests-workflow:
         runs-on: ubuntu-latest
         steps:
-            - name: Install Python Test requirementsStub action
-              shell: bash
-              run: ls
-                          
+          - name: Create Infra
+            uses: ./.github/workflows/integration_tests_infra_create.yml

--- a/.github/workflows/integration_tests_full.yml
+++ b/.github/workflows/integration_tests_full.yml
@@ -1,11 +1,3 @@
-
-# TBD
-# Should execute sub-workflows
-
-# - infra_create
-# - execute tests
-# - infra delete
-
 name: Integration tests - Full Workflow
 env:
     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -22,3 +14,8 @@ jobs:
         uses: ./.github/workflows/integration_tests_execute.yml
         needs: job-create-infra
         secrets: inherit
+
+    job-delete-infra:
+        uses: ./.github/workflows/integration_tests_infra_delete.yml
+        needs: job-execute-tests
+        secrets: inherit        

--- a/.github/workflows/integration_tests_full.yml
+++ b/.github/workflows/integration_tests_full.yml
@@ -14,11 +14,11 @@ env:
 run-name: integration tests - full
 on: [workflow_dispatch]
 jobs:
-    full-integration-tests-workflow:
-        runs-on: ubuntu-latest
-        steps:
-          - name: Check out repository code
-            uses: actions/checkout@v4   
-
     job-create-infra:
         uses: ./.github/workflows/integration_tests_infra_create.yml
+        secrets: inherit
+
+    job-execute-tests:
+        uses: ./.github/workflows/integration_tests_execute.yml
+        needs: job-create-infra
+        secrets: inherit

--- a/.github/workflows/integration_tests_full.yml
+++ b/.github/workflows/integration_tests_full.yml
@@ -17,5 +17,8 @@ jobs:
     full-integration-tests-workflow:
         runs-on: ubuntu-latest
         steps:
+          - name: Check out repository code
+            uses: actions/checkout@v4   
+
           - name: Create Infra
             uses: ./.github/workflows/integration_tests_infra_create.yml

--- a/.github/workflows/integration_tests_full.yml
+++ b/.github/workflows/integration_tests_full.yml
@@ -4,7 +4,11 @@ env:
     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     AWS_DEFAULT_REGION: 'eu-central-1'
 run-name: integration tests - full
-on: [workflow_dispatch]
+on: 
+    push:
+        branches:
+          - main    
+    workflow_dispatch:
 jobs:
     job-create-infra:
         uses: ./.github/workflows/integration_tests_infra_create.yml

--- a/.github/workflows/integration_tests_full.yml
+++ b/.github/workflows/integration_tests_full.yml
@@ -20,5 +20,5 @@ jobs:
           - name: Check out repository code
             uses: actions/checkout@v4   
 
-          - name: Create Infra
-            uses: ./.github/workflows/integration_tests_infra_create.yml
+    job-create-infra:
+        uses: ./.github/workflows/integration_tests_infra_create.yml

--- a/.github/workflows/integration_tests_infra_create.yml
+++ b/.github/workflows/integration_tests_infra_create.yml
@@ -9,7 +9,9 @@ env:
     STAGE_NAME: devit
     SETTING_FOLDER_NAME: "integration_tests/settings"
 run-name: integration tests - create infra
-on: [workflow_dispatch]
+on: 
+  workflow_dispatch:
+  workflow_call:
 jobs:
   integration-testing-create-infra:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration_tests_infra_create.yml
+++ b/.github/workflows/integration_tests_infra_create.yml
@@ -2,7 +2,6 @@ name: Integration tests - Create Infra
 env:
     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}  # temp for testing
     AWS_DEFAULT_REGION: 'eu-central-1'
     CDK_INTEGRATION_TESTS_FOLDER: integration_tests/cdk
     CDK_TOOLING_ENV_FOLDER: infra_tooling_account

--- a/.github/workflows/integration_tests_infra_delete.yml
+++ b/.github/workflows/integration_tests_infra_delete.yml
@@ -9,7 +9,9 @@ env:
     STAGE_NAME: devit
     SETTING_FOLDER_NAME: "integration_tests/settings"
 run-name: integration tests - delete infra
-on: [workflow_dispatch]
+on: 
+  workflow_dispatch:
+  repository_dispatch:
 jobs:
   integration-testing-delete-infra:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration_tests_infra_delete.yml
+++ b/.github/workflows/integration_tests_infra_delete.yml
@@ -2,7 +2,6 @@ name: Integration tests - Delete Infra
 env:
     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-    AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}  # temp for testing
     AWS_DEFAULT_REGION: 'eu-central-1'
     CDK_INTEGRATION_TESTS_FOLDER: integration_tests/cdk
     CDK_TOOLING_ENV_FOLDER: infra_tooling_account

--- a/.github/workflows/integration_tests_infra_delete.yml
+++ b/.github/workflows/integration_tests_infra_delete.yml
@@ -11,7 +11,7 @@ env:
 run-name: integration tests - delete infra
 on: 
   workflow_dispatch:
-  repository_dispatch:
+  workflow_call:
 jobs:
   integration-testing-delete-infra:
     runs-on: ubuntu-latest

--- a/cdk/.gitignore
+++ b/cdk/.gitignore
@@ -1,0 +1,11 @@
+*.swp
+package-lock.json
+__pycache__
+.pytest_cache
+.venv
+*.egg-info
+cdk-deploy.ps1
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out

--- a/cdk/README.md
+++ b/cdk/README.md
@@ -1,7 +1,10 @@
 
 This folder contains subfolders with CDK application:
 
+Core SALMON components:  
 1. (to be migrated here) tooling_environment
 2. (to be migrated here) monitoring_environment
+
+Optional components (if you want to run automated integration tests):  
 3. github_actions_resources - resources needed to run GitHub actions workflows (namely, IAM service user)
 4. (to be migrated here) integration tests: testing stand + AWS resources required for tests execution

--- a/cdk/README.md
+++ b/cdk/README.md
@@ -1,0 +1,7 @@
+
+This folder contains subfolders with CDK application:
+
+1. (to be migrated here) tooling_environment
+2. (to be migrated here) monitoring_environment
+3. github_actions_resources - resources needed to run GitHub actions workflows (namely, IAM service user)
+4. (to be migrated here) integration tests: testing stand + AWS resources required for tests execution

--- a/cdk/github_actions_resources/app.py
+++ b/cdk/github_actions_resources/app.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+import os
+import sys
+import logging
+
+import aws_cdk as cdk
+
+from stacks.github_actions_resources_stack import GitHubActionsResourcesStack
+
+app = cdk.App()
+
+PROJECT_NAME = "salmon"
+STAGE_NAME = "all" # resources are shared among all salmon environments 
+
+main_stack = GitHubActionsResourcesStack(
+    app,
+    f"cf-{PROJECT_NAME}-GithubActionsResources-{STAGE_NAME}",
+)
+
+app.synth()

--- a/cdk/github_actions_resources/cdk.json
+++ b/cdk/github_actions_resources/cdk.json
@@ -1,0 +1,61 @@
+{
+  "app": "python app.py",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "requirements*.txt",
+      "source.bat",
+      "**/__init__.py",
+      "**/__pycache__",
+      "tests"
+    ]
+  },
+  "context": {
+    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+    "@aws-cdk/core:checkSecretUsage": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ],
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,
+    "@aws-cdk/aws-iam:minimizePolicies": true,
+    "@aws-cdk/core:validateSnapshotRemovalPolicy": true,
+    "@aws-cdk/aws-codepipeline:crossAccountKeyAliasStackSafeResourceName": true,
+    "@aws-cdk/aws-s3:createDefaultLoggingPolicy": true,
+    "@aws-cdk/aws-sns-subscriptions:restrictSqsDescryption": true,
+    "@aws-cdk/aws-apigateway:disableCloudWatchRole": true,
+    "@aws-cdk/core:enablePartitionLiterals": true,
+    "@aws-cdk/aws-events:eventsTargetQueueSameAccount": true,
+    "@aws-cdk/aws-iam:standardizedServicePrincipals": true,
+    "@aws-cdk/aws-ecs:disableExplicitDeploymentControllerForCircuitBreaker": true,
+    "@aws-cdk/aws-iam:importedRoleStackSafeDefaultPolicyName": true,
+    "@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy": true,
+    "@aws-cdk/aws-route53-patters:useCertificate": true,
+    "@aws-cdk/customresources:installLatestAwsSdkDefault": false,
+    "@aws-cdk/aws-rds:databaseProxyUniqueResourceName": true,
+    "@aws-cdk/aws-codedeploy:removeAlarmsFromDeploymentGroup": true,
+    "@aws-cdk/aws-apigateway:authorizerChangeDeploymentLogicalId": true,
+    "@aws-cdk/aws-ec2:launchTemplateDefaultUserData": true,
+    "@aws-cdk/aws-secretsmanager:useAttachedSecretResourcePolicyForSecretTargetAttachments": true,
+    "@aws-cdk/aws-redshift:columnId": true,
+    "@aws-cdk/aws-stepfunctions-tasks:enableEmrServicePolicyV2": true,
+    "@aws-cdk/aws-ec2:restrictDefaultSecurityGroup": true,
+    "@aws-cdk/aws-apigateway:requestValidatorUniqueId": true,
+    "@aws-cdk/aws-kms:aliasNameRef": true,
+    "@aws-cdk/aws-autoscaling:generateLaunchTemplateInsteadOfLaunchConfig": true,
+    "@aws-cdk/core:includePrefixInUniqueNameGeneration": true,
+    "@aws-cdk/aws-efs:denyAnonymousAccess": true,
+    "@aws-cdk/aws-opensearchservice:enableOpensearchMultiAzWithStandby": true,
+    "@aws-cdk/aws-lambda-nodejs:useLatestRuntimeVersion": true,
+    "@aws-cdk/aws-efs:mountTargetOrderInsensitiveLogicalId": true,
+    "@aws-cdk/aws-rds:auroraClusterChangeScopeOfInstanceParameterGroupWithEachParameters": true,
+    "@aws-cdk/aws-appsync:useArnForSourceApiAssociationIdentifier": true,
+    "@aws-cdk/aws-rds:preventRenderingDeprecatedCredentials": true
+  }
+}

--- a/cdk/github_actions_resources/stacks/github_actions_resources_stack.py
+++ b/cdk/github_actions_resources/stacks/github_actions_resources_stack.py
@@ -59,8 +59,6 @@ class GitHubActionsResourcesStack(Stack):
                                          resources=["*"],  # todo: restrict to specific resources
                                      )
                                  ])
-
-        # Attach the Glue policy to the IAM user
         iam_user.attach_inline_policy(glue_policy) 
 
         # Policy for Integration Tests (Lambda Functions)
@@ -81,10 +79,9 @@ class GitHubActionsResourcesStack(Stack):
                                                   resources=["*"],  # todo: restrict to specific resources
                                               )
                                           ])
-
-        # Attach the combined policy to the IAM user
         iam_user.attach_inline_policy(lambda_runner_policy)
 
+        # Policy for Integration Tests (SQS Queue)
         sqs_queue_reader_policy = iam.Policy(self, "SqsQueueReaderPolicy",
                                              policy_name="SqsQueueReaderPolicy",
                                              statements=[
@@ -101,6 +98,23 @@ class GitHubActionsResourcesStack(Stack):
                                                      resources=["*"],  # todo: restrict to specific resources
                                                  )
                                              ])
-
-        # Attach the policy to the IAM user
         iam_user.attach_inline_policy(sqs_queue_reader_policy)        
+
+        # Policy for Integration Tests (Timestream DB interactions)
+        timestream_query_runner_policy = iam.Policy(self, "TimestreamQueryRunnerPolicy",
+                                                    policy_name="TimestreamQueryRunnerPolicy",
+                                                    statements=[
+                                                        iam.PolicyStatement(
+                                                            actions=[
+                                                                # Timestream query actions
+                                                                "timestream:Select",
+                                                                "timestream:DescribeTable",
+                                                                "timestream:ListMeasures",
+                                                                "timestream:DescribeEndpoints",
+                                                            ],
+                                                            resources=["*"],  # Adjust as necessary to restrict to specific resources
+                                                        )
+                                                    ])
+
+        # Attach the Timestream query policy to the IAM user
+        iam_user.attach_inline_policy(timestream_query_runner_policy)        

--- a/cdk/github_actions_resources/stacks/github_actions_resources_stack.py
+++ b/cdk/github_actions_resources/stacks/github_actions_resources_stack.py
@@ -44,3 +44,63 @@ class GitHubActionsResourcesStack(Stack):
                                             )
                                         ])
         iam_user.attach_inline_policy(assume_role_policy)  
+
+        # Policy for Integration Tests (Glue Job)
+        glue_policy = iam.Policy(self, "GlueJobRunnerPolicy",
+                                 policy_name="GlueJobRunnerPolicy",
+                                 statements=[
+                                     iam.PolicyStatement(
+                                         actions=[
+                                             "glue:StartJobRun",
+                                             "glue:GetJobRun",
+                                             "glue:GetJob",
+                                             "glue:ListJobs"
+                                         ],
+                                         resources=["*"],  # todo: restrict to specific resources
+                                     )
+                                 ])
+
+        # Attach the Glue policy to the IAM user
+        iam_user.attach_inline_policy(glue_policy) 
+
+        # Policy for Integration Tests (Lambda Functions)
+        lambda_runner_policy = iam.Policy(self, "LambdaRunnerPolicy",
+                                          policy_name="LambdaRunnerPolicy",
+                                          statements=[
+                                              iam.PolicyStatement(
+                                                  actions=[
+                                                      # Lambda actions
+                                                      "lambda:InvokeFunction",
+                                                      # CloudWatch Logs actions
+                                                      "logs:FilterLogEvents",
+                                                      "logs:GetLogEvents",
+                                                      "logs:StartQuery",
+                                                      "logs:GetQueryResults",
+                                                      "logs:DescribeLogGroups",
+                                                  ],
+                                                  resources=["*"],  # todo: restrict to specific resources
+                                              )
+                                          ])
+
+        # Attach the combined policy to the IAM user
+        iam_user.attach_inline_policy(lambda_runner_policy)
+
+        sqs_queue_reader_policy = iam.Policy(self, "SqsQueueReaderPolicy",
+                                             policy_name="SqsQueueReaderPolicy",
+                                             statements=[
+                                                 iam.PolicyStatement(
+                                                     actions=[
+                                                         # SQS actions
+                                                         "sqs:ReceiveMessage",
+                                                         "sqs:GetQueueAttributes",
+                                                         "sqs:ListQueues",  # Optional
+                                                         "sqs:GetQueueUrl",
+                                                         # STS actions
+                                                         "sts:GetCallerIdentity",
+                                                     ],
+                                                     resources=["*"],  # todo: restrict to specific resources
+                                                 )
+                                             ])
+
+        # Attach the policy to the IAM user
+        iam_user.attach_inline_policy(sqs_queue_reader_policy)        

--- a/cdk/github_actions_resources/stacks/github_actions_resources_stack.py
+++ b/cdk/github_actions_resources/stacks/github_actions_resources_stack.py
@@ -13,109 +13,141 @@ class GitHubActionsResourcesStack(Stack):
     def __init__(self, scope: Construct, id: str, **kwargs) -> None:
         super().__init__(scope, id, **kwargs)
 
-        iam_user = iam.User(self, "GithubActionsServiceUser",
-                            user_name="github-actions-service-user",
-                            )
-        
-        access_key = iam.CfnAccessKey(self, "GithubActionsUserAccessKey",
-                                      user_name=iam_user.user_name)
+        iam_user = iam.User(
+            self,
+            "GithubActionsServiceUser",
+            user_name="github-actions-service-user",
+        )
+
+        access_key = iam.CfnAccessKey(
+            self, "GithubActionsUserAccessKey", user_name=iam_user.user_name
+        )
 
         # Store the credentials in Secrets Manager
-        secret = secretsmanager.Secret(self, "GithubActionsUserSecret",
-                                       secret_name="secret/salmon/github-actions-service-user",
-                                       generate_secret_string=secretsmanager.SecretStringGenerator(
-                                           secret_string_template=json.dumps({
-                                               "AccessKeyId": access_key.ref,
-                                               "SecretAccessKey": access_key.attr_secret_access_key,
-                                           }),
-                                           generate_string_key="dummy",
-                                       ))
-        
-        assume_role_policy = iam.Policy(self, "AssumeRolePolicy",
-                                        policy_name="AssumeRolePolicy",
-                                        statements=[
-                                            iam.PolicyStatement(
-                                                effect=iam.Effect.ALLOW,
-                                                actions=["sts:AssumeRole"],
-                                                resources=[
-                                                    "arn:aws:iam::*:role/cdk-*-deploy-role-*",
-                                                    "arn:aws:iam::*:role/cdk-*-file-publishing-role-*"
-                                                ]
-                                            )
-                                        ])
-        iam_user.attach_inline_policy(assume_role_policy)  
+        secret = secretsmanager.Secret(
+            self,
+            "GithubActionsUserSecret",
+            secret_name="secret/salmon/github-actions-service-user",
+            generate_secret_string=secretsmanager.SecretStringGenerator(
+                secret_string_template=json.dumps(
+                    {
+                        "AccessKeyId": access_key.ref,
+                        "SecretAccessKey": access_key.attr_secret_access_key,
+                    }
+                ),
+                generate_string_key="dummy",
+            ),
+        )
 
-        # Policy for Integration Tests (Glue Job)
-        glue_policy = iam.Policy(self, "GlueJobRunnerPolicy",
-                                 policy_name="GlueJobRunnerPolicy",
-                                 statements=[
-                                     iam.PolicyStatement(
-                                         actions=[
-                                             "glue:StartJobRun",
-                                             "glue:GetJobRun",
-                                             "glue:GetJob",
-                                             "glue:ListJobs"
-                                         ],
-                                         resources=["*"],  # todo: restrict to specific resources
-                                     )
-                                 ])
-        iam_user.attach_inline_policy(glue_policy) 
+        # Attach policies to the IAM user
+        self.attach_assume_role_policy(iam_user)
+        self.attach_glue_job_runner_policy(iam_user)
+        self.attach_lambda_runner_policy(iam_user)
+        self.attach_sqs_queue_reader_policy(iam_user)
+        self.attach_timestream_query_runner_policy(iam_user)
 
+    def attach_assume_role_policy(self, iam_user):
+        # Permissions needed to CDK deploy/destroy
+        assume_role_policy = iam.Policy(
+            self,
+            "AssumeRolePolicy",
+            policy_name="AssumeRolePolicy",
+            statements=[
+                iam.PolicyStatement(
+                    effect=iam.Effect.ALLOW,
+                    actions=["sts:AssumeRole"],
+                    resources=[
+                        "arn:aws:iam::*:role/cdk-*-deploy-role-*",
+                        "arn:aws:iam::*:role/cdk-*-file-publishing-role-*",
+                    ],
+                )
+            ],
+        )
+        iam_user.attach_inline_policy(assume_role_policy)
+
+    def attach_glue_job_runner_policy(self, iam_user):
+        # Policy for Integration Tests (Glue Jobs)
+        glue_policy = iam.Policy(
+            self,
+            "GlueJobRunnerPolicy",
+            policy_name="GlueJobRunnerPolicy",
+            statements=[
+                iam.PolicyStatement(
+                    actions=[
+                        "glue:StartJobRun",
+                        "glue:GetJobRun",
+                        "glue:GetJob",
+                        "glue:ListJobs",
+                    ],
+                    resources=["*"],  # todo: restrict to specific resources
+                )
+            ],
+        )
+        iam_user.attach_inline_policy(glue_policy)
+
+    def attach_lambda_runner_policy(self, iam_user):
         # Policy for Integration Tests (Lambda Functions)
-        lambda_runner_policy = iam.Policy(self, "LambdaRunnerPolicy",
-                                          policy_name="LambdaRunnerPolicy",
-                                          statements=[
-                                              iam.PolicyStatement(
-                                                  actions=[
-                                                      # Lambda actions
-                                                      "lambda:InvokeFunction",
-                                                      # CloudWatch Logs actions
-                                                      "logs:FilterLogEvents",
-                                                      "logs:GetLogEvents",
-                                                      "logs:StartQuery",
-                                                      "logs:GetQueryResults",
-                                                      "logs:DescribeLogGroups",
-                                                  ],
-                                                  resources=["*"],  # todo: restrict to specific resources
-                                              )
-                                          ])
+        lambda_runner_policy = iam.Policy(
+            self,
+            "LambdaRunnerPolicy",
+            policy_name="LambdaRunnerPolicy",
+            statements=[
+                iam.PolicyStatement(
+                    actions=[
+                        # Lambda actions
+                        "lambda:InvokeFunction",
+                        # CloudWatch Logs actions
+                        "logs:FilterLogEvents",
+                        "logs:GetLogEvents",
+                        "logs:StartQuery",
+                        "logs:GetQueryResults",
+                        "logs:DescribeLogGroups",
+                    ],
+                    resources=["*"],  # todo: restrict to specific resources
+                )
+            ],
+        )
         iam_user.attach_inline_policy(lambda_runner_policy)
 
-        # Policy for Integration Tests (SQS Queue)
-        sqs_queue_reader_policy = iam.Policy(self, "SqsQueueReaderPolicy",
-                                             policy_name="SqsQueueReaderPolicy",
-                                             statements=[
-                                                 iam.PolicyStatement(
-                                                     actions=[
-                                                         # SQS actions
-                                                         "sqs:ReceiveMessage",
-                                                         "sqs:GetQueueAttributes",
-                                                         "sqs:ListQueues",  # Optional
-                                                         "sqs:GetQueueUrl",
-                                                         # STS actions
-                                                         "sts:GetCallerIdentity",
-                                                     ],
-                                                     resources=["*"],  # todo: restrict to specific resources
-                                                 )
-                                             ])
-        iam_user.attach_inline_policy(sqs_queue_reader_policy)        
+    def attach_sqs_queue_reader_policy(self, iam_user):
+        sqs_queue_reader_policy = iam.Policy(
+            self,
+            "SqsQueueReaderPolicy",
+            policy_name="SqsQueueReaderPolicy",
+            statements=[
+                iam.PolicyStatement(
+                    actions=[
+                        # SQS actions
+                        "sqs:ReceiveMessage",
+                        "sqs:GetQueueAttributes",
+                        "sqs:ListQueues",  # Optional
+                        "sqs:GetQueueUrl",
+                        # STS actions
+                        "sts:GetCallerIdentity",
+                    ],
+                    resources=["*"],  # todo: restrict to specific resources
+                )
+            ],
+        )
+        iam_user.attach_inline_policy(sqs_queue_reader_policy)
 
-        # Policy for Integration Tests (Timestream DB interactions)
-        timestream_query_runner_policy = iam.Policy(self, "TimestreamQueryRunnerPolicy",
-                                                    policy_name="TimestreamQueryRunnerPolicy",
-                                                    statements=[
-                                                        iam.PolicyStatement(
-                                                            actions=[
-                                                                # Timestream query actions
-                                                                "timestream:Select",
-                                                                "timestream:DescribeTable",
-                                                                "timestream:ListMeasures",
-                                                                "timestream:DescribeEndpoints", # align with tooling stack - separate statement
-                                                                "kms:Decrypt"
-                                                            ],
-                                                            resources=["*"],  # Adjust as necessary to restrict to specific resources
-                                                        )
-                                                    ])
-
-        # Attach the Timestream query policy to the IAM user
-        iam_user.attach_inline_policy(timestream_query_runner_policy)        
+    def attach_timestream_query_runner_policy(self, iam_user):
+        timestream_query_runner_policy = iam.Policy(
+            self,
+            "TimestreamQueryRunnerPolicy",
+            policy_name="TimestreamQueryRunnerPolicy",
+            statements=[
+                iam.PolicyStatement(
+                    actions=[
+                        # Timestream query actions
+                        "timestream:Select",
+                        "timestream:DescribeTable",
+                        "timestream:ListMeasures",
+                        "timestream:DescribeEndpoints",  # align with tooling stack - separate statement
+                        "kms:Decrypt",
+                    ],
+                    resources=["*"],  # todo: restrict to specific resources
+                )
+            ],
+        )
+        iam_user.attach_inline_policy(timestream_query_runner_policy)

--- a/cdk/github_actions_resources/stacks/github_actions_resources_stack.py
+++ b/cdk/github_actions_resources/stacks/github_actions_resources_stack.py
@@ -110,7 +110,8 @@ class GitHubActionsResourcesStack(Stack):
                                                                 "timestream:Select",
                                                                 "timestream:DescribeTable",
                                                                 "timestream:ListMeasures",
-                                                                "timestream:DescribeEndpoints",
+                                                                "timestream:DescribeEndpoints", # align with tooling stack - separate statement
+                                                                "kms:Decrypt"
                                                             ],
                                                             resources=["*"],  # Adjust as necessary to restrict to specific resources
                                                         )

--- a/cdk/github_actions_resources/stacks/github_actions_resources_stack.py
+++ b/cdk/github_actions_resources/stacks/github_actions_resources_stack.py
@@ -1,0 +1,46 @@
+import json
+
+from aws_cdk import (
+    Stack,
+    Tags,
+    aws_iam as iam,
+    aws_secretsmanager as secretsmanager,
+)
+from constructs import Construct
+
+
+class GitHubActionsResourcesStack(Stack):
+    def __init__(self, scope: Construct, id: str, **kwargs) -> None:
+        super().__init__(scope, id, **kwargs)
+
+        iam_user = iam.User(self, "GithubActionsServiceUser",
+                            user_name="github-actions-service-user",
+                            )
+        
+        access_key = iam.CfnAccessKey(self, "GithubActionsUserAccessKey",
+                                      user_name=iam_user.user_name)
+
+        # Store the credentials in Secrets Manager
+        secret = secretsmanager.Secret(self, "GithubActionsUserSecret",
+                                       secret_name="secret/salmon/github-actions-service-user",
+                                       generate_secret_string=secretsmanager.SecretStringGenerator(
+                                           secret_string_template=json.dumps({
+                                               "AccessKeyId": access_key.ref,
+                                               "SecretAccessKey": access_key.attr_secret_access_key,
+                                           }),
+                                           generate_string_key="dummy",
+                                       ))
+        
+        assume_role_policy = iam.Policy(self, "AssumeRolePolicy",
+                                        policy_name="AssumeRolePolicy",
+                                        statements=[
+                                            iam.PolicyStatement(
+                                                effect=iam.Effect.ALLOW,
+                                                actions=["sts:AssumeRole"],
+                                                resources=[
+                                                    "arn:aws:iam::*:role/cdk-*-deploy-role-*",
+                                                    "arn:aws:iam::*:role/cdk-*-file-publishing-role-*"
+                                                ]
+                                            )
+                                        ])
+        iam_user.attach_inline_policy(assume_role_policy)  


### PR DESCRIPTION
1. Github actions service user credentials are used in GitHub workflows (CDK deployment tests, Integration tests)
2. If you choose to use integration tests together with Salmon - you need to deploy CDK app for github actions resources (currently, it's IAM user only + it's privileges).
3. Privileges granted IAM user are minimally sufficient for:
- deploying / destroying integration and deployment tests infra
- executing integration tests (interaction with testing stand resources to launch them + working with tooling env to extract metrics / analyze alerts )
4. Restructured CDK part of the project.
Created a separate folder "cdk" where all CDK Salmon apps should reside (some app are yet to be moved there)
5. Integration tests are designed in a way, so they:
- can be executed "all steps in one" meaning create infra->execute tests->delete infra (Full IntTest workflow)
- can be executed separately (e.g. create infra once, but execute tests multiple time - separate workflows)

- can be executed via GitHub actions, but also from local computer, e.g.:
`python integration_tests/testing_stand_execution.py --stage-name=devit --region=eu-central-1`
`pytest integration_tests/tests --stage-name=devit --region=eu-central-1 --start-epochtimemsec=1723548392000`
(start-epochtimemsec value should be taken from testing_stand_execution.py)