### PR TITLE
Tests/add grafana stack to deployment tests

### DIFF
--- a/cdk/github_actions_resources/stacks/github_actions_resources_stack.py
+++ b/cdk/github_actions_resources/stacks/github_actions_resources_stack.py
@@ -83,7 +83,14 @@ class GitHubActionsResourcesStack(Stack):
             statements=[
                 iam.PolicyStatement(
                     effect=iam.Effect.ALLOW,
-                    actions=["ec2:DescribeVpcs", "ec2:DescribeSecurityGroups"],
+                    actions=[
+                        "ec2:DescribeVpcs",
+                        "ec2:DescribeSecurityGroups",
+                        "ec2:DescribeImages",
+                        "ec2:DescribeSubnets",
+                        "ec2:DescribeRouteTables",
+                        "ec2:DescribeVpnGateways",
+                    ],
                     resources=["*"],
                 )
             ],

--- a/cdk/github_actions_resources/stacks/github_actions_resources_stack.py
+++ b/cdk/github_actions_resources/stacks/github_actions_resources_stack.py
@@ -45,6 +45,7 @@ class GitHubActionsResourcesStack(Stack):
 
         # Attach policies to the IAM user
         self.attach_assume_role_policy(iam_user)
+        self.attach_ec2_role_policy(iam_user)
         self.attach_glue_job_runner_policy(iam_user)
         self.attach_glue_dq_runner_policy(iam_user)
         self.attach_glue_workflow_runner_policy(iam_user)
@@ -68,6 +69,22 @@ class GitHubActionsResourcesStack(Stack):
                         "arn:aws:iam::*:role/cdk-*-deploy-role-*",
                         "arn:aws:iam::*:role/cdk-*-file-publishing-role-*",
                     ],
+                )
+            ],
+            users=[iam_user],
+        )
+
+    def attach_ec2_role_policy(self, iam_user):
+        # Permissions needed to CDK deploy/destroy of Grafana stack
+        ec2_role_policy = iam.Policy(
+            self,
+            "EC2RolePolicy",
+            policy_name="EC2RolePolicy",
+            statements=[
+                iam.PolicyStatement(
+                    effect=iam.Effect.ALLOW,
+                    actions=["ec2:DescribeVpcs", "ec2:DescribeSecurityGroups"],
+                    resources=["*"],
                 )
             ],
             users=[iam_user],

--- a/tests/devcdk/prepare_settings.py
+++ b/tests/devcdk/prepare_settings.py
@@ -6,6 +6,12 @@ import os
 # The script can be modified for any specific set of config files
 
 
+class PrepareSettingsException(Exception):
+    """Exception raised for errors encountered while preparing test settings."""
+
+    pass
+
+
 def get_aws_account_id():
     session = boto3.Session()
     sts_client = session.client("sts")
@@ -14,15 +20,48 @@ def get_aws_account_id():
     return account_id
 
 
+def get_vpc_id():
+    """Required for the deployment of Grafana stack"""
+    session = boto3.Session()
+    ec2_client = session.client("ec2")
+    response = ec2_client.describe_vpcs(
+        Filters=[{"Name": "isDefault", "Values": ["true"]}]
+    )
+
+    try:
+        vpc_id = response["Vpcs"][0]["VpcId"]
+        return vpc_id
+    except Exception as ex:
+        raise PrepareSettingsException(f"Error while getting default VPC ID: {str(ex)}")
+
+
+def get_security_group_id():
+    """Required for the deployment of Grafana stack"""
+    session = boto3.Session()
+    ec2_client = session.client("ec2")
+    response = ec2_client.describe_security_groups(GroupNames=["default"])
+
+    try:
+        security_group_id = response["SecurityGroups"][0]["GroupId"]
+        return security_group_id
+    except Exception as ex:
+        raise PrepareSettingsException(
+            f"Error while getting default security group ID: {str(ex)}"
+        )
+
+
 def read_replacements_file(file_path):
     with open(file_path, "r") as file:
         data = json.load(file)
     return data
 
 
-def update_replacements_file(file_path, aws_account_id):
+def update_replacements_file(file_path, aws_account_id, vpc_id, security_group_id):
     data = read_replacements_file(file_path)
     data["<<main_account_id>>"] = aws_account_id
+    data["<<grafana_vpc_id>>"] = vpc_id
+    data["<<grafana_security_group_id>>"] = security_group_id
+
     with open(file_path, "w") as file:
         json.dump(data, file, indent=4)
 
@@ -32,7 +71,9 @@ def main():
     file_path = os.path.join(script_dir, "settings", "replacements.json")
 
     aws_account_id = get_aws_account_id()
-    update_replacements_file(file_path, aws_account_id)
+    vpc_id = get_vpc_id()
+    security_group_id = get_security_group_id()
+    update_replacements_file(file_path, aws_account_id, vpc_id, security_group_id)
     print(f"Updated replacements.json with AWS Account ID: {aws_account_id}")
 
 

--- a/tests/devcdk/prepare_settings.py
+++ b/tests/devcdk/prepare_settings.py
@@ -35,11 +35,13 @@ def get_vpc_id():
         raise PrepareSettingsException(f"Error while getting default VPC ID: {str(ex)}")
 
 
-def get_security_group_id():
+def get_security_group_id(vpc_id):
     """Required for the deployment of Grafana stack"""
     session = boto3.Session()
     ec2_client = session.client("ec2")
-    response = ec2_client.describe_security_groups(GroupNames=["default"])
+    response = ec2_client.describe_security_groups(
+        Filters=[{"Name": "vpc-id", "Values": [vpc_id]}], GroupNames=["default"]
+    )
 
     try:
         security_group_id = response["SecurityGroups"][0]["GroupId"]
@@ -72,7 +74,7 @@ def main():
 
     aws_account_id = get_aws_account_id()
     vpc_id = get_vpc_id()
-    security_group_id = get_security_group_id()
+    security_group_id = get_security_group_id(vpc_id)
     update_replacements_file(file_path, aws_account_id, vpc_id, security_group_id)
     print(f"Updated replacements.json with AWS Account ID: {aws_account_id}")
 

--- a/tests/devcdk/settings/general.json
+++ b/tests/devcdk/settings/general.json
@@ -4,7 +4,11 @@
         "account_id": "<<main_account_id>>",
         "region": "eu-central-1",
         "digest_report_period_hours" : 72, 
-        "metrics_collection_cron_expression": "cron(*/5 * * * ? 2199)"
+        "metrics_collection_cron_expression": "cron(*/5 * * * ? 2199)",
+        "grafana_instance": {
+            "grafana_vpc_id": "<<grafana_vpc_id>>",
+            "grafana_security_group_id": "<<grafana_security_group_id>>"
+        }
     },
     "monitored_environments": [    
         {

--- a/tests/devcdk/settings/replacements.json
+++ b/tests/devcdk/settings/replacements.json
@@ -1,3 +1,5 @@
 {
-    "<<main_account_id>>": "to be replaced"
+    "<<main_account_id>>": "to be replaced",
+    "<<grafana_vpc_id>>": "to be replaced", 
+    "<<grafana_security_group_id>>": "to be replaced"
 }


### PR DESCRIPTION
- is-default - Indicates whether the VPC is the default VPC https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2/client/describe_vpcs.html
- the name of the default security group is "default" https://docs.aws.amazon.com/vpc/latest/userguide/default-security-group.html 

- grafana stack deployed successfully

![image](https://github.com/user-attachments/assets/c47b7b75-6827-4567-be7c-264a945df1b2)

![image](https://github.com/user-attachments/assets/06b171e8-aeb7-45e7-aeef-269535c34674)

![image](https://github.com/user-attachments/assets/19aa0b58-4c48-44b1-92be-7981c003944a)


