### PR TITLE
update the since_time for metrics extraction

### DIFF
--- a/src/lambda_extract_metrics.py
+++ b/src/lambda_extract_metrics.py
@@ -2,15 +2,16 @@ import os
 import boto3
 import logging
 from itertools import groupby
+from datetime import datetime
 
 from lib.aws import AWSNaming, Boto3ClientCreator, TimestreamTableWriter
 from lib.aws.glue_manager import GlueManager
 from lib.settings import Settings
 from lib.core.constants import SettingConfigs
 
-from lib.metrics_extractor import MetricsExtractorProvider
+from lib.metrics_extractor import MetricsExtractorProvider, BaseMetricsExtractor
 from lib.metrics_extractor.metrics_extractor_utils import (
-    get_last_update_time,
+    get_resource_last_update_time,
     get_earliest_last_update_time_for_resource_set,
 )
 from lib.core.constants import SettingConfigResourceTypes as types
@@ -48,6 +49,48 @@ def collect_glue_data_quality_result_ids(
     return result_ids
 
 
+def get_since_time_for_individual_resource(
+    last_update_times: dict,
+    resource_type: str,
+    resource_name: str,
+    metrics_extractor: BaseMetricsExtractor,
+    timestream_writer: TimestreamTableWriter,
+) -> datetime:
+    since_time = get_resource_last_update_time(
+        last_update_times, resource_type, resource_name
+    )
+    print(f"Type since time {type(since_time)}")
+    logger.info(
+        f"Last update time (from payload) for {resource_type}[{resource_name}] = {since_time}"
+    )
+
+    if since_time is None:
+        # if last_update_time was not given or missing - query for specific resource directly from table
+        logger.info(
+            f"No last_update_time for {resource_type}[{resource_name}] - querying directly from table"
+        )
+        since_time = metrics_extractor.get_last_update_time(
+            timestream_query_client=timestream_query_client
+        )
+
+    # get the earliest time that Timestream can accept for writing
+    earliest_time = timestream_writer.get_earliest_writeable_time_for_table()
+
+    # if since_time is still not defined or older than the earliest acceptable time,
+    # then extract since time which Timestream is able to accept
+    if since_time is None or since_time < earliest_time:
+        logger.info(
+            f"No last_update_time for {resource_type}[{resource_name}] or it's earlier than the earliest writeable time - querying from {earliest_time}."
+        )
+        since_time = earliest_time
+
+    logger.info(
+        f"Extracting metrics since {since_time} for resource {resource_type}[{resource_name}]"
+    )
+
+    return since_time
+
+
 def process_individual_resource(
     monitored_environment_name: str,
     resource_type: str,
@@ -78,27 +121,13 @@ def process_individual_resource(
     logger.info(f"Created metrics extractor of type {type(metrics_extractor)}")
 
     # 2. Get time of this entity's data latest update (we append data since that time only)
-    since_time = get_last_update_time(last_update_times, resource_type, resource_name)
-    logger.info(
-        f"Last update time (from payload) for {resource_type}[{resource_name}] = {since_time}"
+    since_time = get_since_time_for_individual_resource(
+        last_update_times=last_update_times,
+        resource_type=resource_type,
+        resource_name=resource_name,
+        metrics_extractor=metrics_extractor,
+        timestream_writer=timestream_writer,
     )
-
-    if since_time is None:
-        # if last_update_time was not given or missing - query for specific resource directly from table
-        logger.info(
-            f"No last_update_time for {resource_type}[{resource_name}] - querying directly from table"
-        )
-        since_time = metrics_extractor.get_last_update_time(
-            timestream_query_client=timestream_query_client
-        )
-
-    if since_time is None:
-        # if still there is no last_update_time - extract since time which Timestream is able to accept
-        logger.info(
-            f"No last_update_time for {resource_type}[{resource_name}] - querying from Timestream"
-        )
-        since_time = timestream_writer.get_earliest_writeable_time_for_table()
-    logger.info(f"Extracting metrics since {since_time}")
 
     # # 3. Set Result IDs for Glue Data Quality resources
     if resource_type == types.GLUE_DATA_QUALITY:
@@ -129,7 +158,11 @@ def process_individual_resource(
         logger.info(f"Alerts have been sent successfully")
         alerts_send = True
 
-    return {"metrics_records_written": metrics_record_count, "alerts_sent": alerts_send}
+    return {
+        "metrics_records_written": metrics_record_count,
+        "alerts_sent": alerts_send,
+        "since_time": since_time,
+    }
 
 
 def process_all_resources_by_env_and_type(

--- a/src/lib/metrics_extractor/__init__.py
+++ b/src/lib/metrics_extractor/__init__.py
@@ -10,7 +10,7 @@ from .emr_serverless_metrics_extractor import EMRServerlessMetricExtractor
 from .metrics_extractor_provider import MetricsExtractorProvider
 from .metrics_extractor_utils import (
     retrieve_last_update_time_for_all_resources,
-    get_last_update_time,
+    get_resource_last_update_time,
     get_earliest_last_update_time_for_resource_set,
     MetricsExtractorException,
 )

--- a/src/lib/metrics_extractor/metrics_extractor_utils.py
+++ b/src/lib/metrics_extractor/metrics_extractor_utils.py
@@ -89,7 +89,7 @@ def retrieve_last_update_time_for_all_resources(
         raise MetricsExtractorException(error_message)
 
 
-def get_last_update_time(
+def get_resource_last_update_time(
     last_update_time_json: dict, resource_type: str, resource_name: str
 ) -> str:
     """

--- a/tests/src/lib/metrics_extractor/test_metrics_extractor_utils.py
+++ b/tests/src/lib/metrics_extractor/test_metrics_extractor_utils.py
@@ -5,7 +5,7 @@ import pytest
 from lib.core.datetime_utils import str_utc_datetime_to_datetime
 from lib.metrics_extractor import (
     retrieve_last_update_time_for_all_resources,
-    get_last_update_time,
+    get_resource_last_update_time,
     get_earliest_last_update_time_for_resource_set,
     MetricsExtractorException,
 )
@@ -152,16 +152,16 @@ def test_retrieve_last_update_time_db_error():
 
 
 def test_get_last_update_time_none_input():
-    assert get_last_update_time(None, "glue_jobs", "glue-job-1") is None
+    assert get_resource_last_update_time(None, "glue_jobs", "glue-job-1") is None
 
 
 def test_get_last_update_time_empty_input():
-    assert get_last_update_time({}, "glue_jobs", "glue-job-1") is None
+    assert get_resource_last_update_time({}, "glue_jobs", "glue-job-1") is None
 
 
 def test_get_last_update_time_no_resource_type(last_update_time_sample_data):
     assert (
-        get_last_update_time(
+        get_resource_last_update_time(
             last_update_time_sample_data, "step_functions", "step-function-1"
         )
         is None
@@ -170,7 +170,7 @@ def test_get_last_update_time_no_resource_type(last_update_time_sample_data):
 
 def test_get_last_update_time_no_resource_name(last_update_time_sample_data):
     assert (
-        get_last_update_time(
+        get_resource_last_update_time(
             last_update_time_sample_data, "glue_jobs", "nonexistent-job"
         )
         is None
@@ -179,7 +179,7 @@ def test_get_last_update_time_no_resource_name(last_update_time_sample_data):
 
 def test_get_last_update_time_valid_input(last_update_time_sample_data):
     expected_datetime = str_utc_datetime_to_datetime("2024-01-09 11:00:40.911000000")
-    actual_datetime = get_last_update_time(
+    actual_datetime = get_resource_last_update_time(
         last_update_time_sample_data, "glue_jobs", "glue-job-1"
     )
     assert actual_datetime == expected_datetime

--- a/tests/src/test_lambda_extract_metrics.py
+++ b/tests/src/test_lambda_extract_metrics.py
@@ -331,7 +331,7 @@ def test_process_individual_resource_no_last_upd_time(
 
 # testing successful flow when we last_update_time olrder the earliest writable time to Timestream
 # testing for "resource_name": "step-function1" with "last_update_time": "2024-04-15 12:05:11.275000000"
-def test_process_individual_resource_last_upd_time_earlier_writeable(
+def test_process_individual_resource_last_upd_time_earlier_writeable_time(
     os_vars_values,
     mock_settings,
     mock_metrics_extractor_from_provider,

--- a/tests/src/test_lambda_extract_metrics.py
+++ b/tests/src/test_lambda_extract_metrics.py
@@ -368,12 +368,12 @@ def test_process_individual_resource_last_upd_time_earlier_writeable(
         result_ids=[],
     )
 
-    mock_metrics_extractor_from_provider.get_last_update_time.assert_not_called()
-    mock_timestream_writer.get_earliest_writeable_time_for_table.assert_called_once()
-
     # since returned last_update_time is older then earlist writable time,
     # the earliest writable time should be used for metrics extraction
+    mock_metrics_extractor_from_provider.get_last_update_time.assert_not_called()
+    mock_timestream_writer.get_earliest_writeable_time_for_table.assert_called_once()
     assert result["since_time"] == EARLIEST_WRITEABLE_TIME
+
     # no alerts sent (glue uses eventbridge for alerts)
     assert result["alerts_sent"] == False, "Alerts shouldn't be sent in this call"
 

--- a/tests/src/test_lambda_extract_metrics.py
+++ b/tests/src/test_lambda_extract_metrics.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 import pytest
 import os
 
@@ -34,7 +34,7 @@ LAST_UPDATE_TIMES_SAMPLE = {
     "step_functions": [
         {
             "resource_name": "step-function1",
-            "last_update_time": "2024-04-16 12:05:11.275000000",
+            "last_update_time": "2024-04-15 12:05:11.275000000",
         },
         {
             "resource_name": "step-function2",
@@ -49,6 +49,8 @@ LAST_UPDATE_TIMES_SAMPLE = {
     ],
 }
 TEST_DQ_RESULT_IDS = ["result-id-1", "result-id-2"]
+EARLIEST_WRITEABLE_TIME = datetime(2024, 4, 16, 0, 0, 0, 000, tzinfo=timezone.utc)
+MOCKED_LAST_UPDATE_TIME = datetime(2024, 4, 16, 15, 5, 11, 200, tzinfo=timezone.utc)
 #########################################################################################
 
 
@@ -134,10 +136,7 @@ def mock_metrics_extractor_from_provider(request):
 
         mocked_extractor = MagicMock(spec=methods)
 
-        mocked_extractor.get_last_update_time.return_value = (
-            "2024-04-16 12:05:11.275000000"
-        )
-
+        mocked_extractor.get_last_update_time.return_value = MOCKED_LAST_UPDATE_TIME
         mocked_extractor.prepare_metrics_data.return_value = (
             ["record1", "record2"],
             ["common_attr1", "common_attr2"],
@@ -155,7 +154,7 @@ def mock_metrics_extractor_from_provider(request):
 def mock_timestream_writer():
     mocked_timestream_writer = MagicMock()
     mocked_timestream_writer.get_earliest_writeable_time_for_table.return_value = (
-        datetime(2000, 1, 1, 0, 0, 0)
+        EARLIEST_WRITEABLE_TIME
     )
 
     with patch(
@@ -180,6 +179,7 @@ def mock_boto3_client_creator():
 
 
 # testing successful flow when we have last_update_time for the resource coming from orchestrator lambda
+# testing "glue-job1" with "last_update_time": "2024-04-16 12:05:11.275000000"
 def test_process_individual_resource_with_last_upd_time(
     os_vars_values,
     mock_settings,
@@ -219,11 +219,12 @@ def test_process_individual_resource_with_last_upd_time(
         result_ids=[],
     )
 
-    # Assert last_update_time is taken directly from arguments
+    # last_update_time will be taken from LAST_UPDATE_TIMES_SAMPLE in this case
     # not from: metrics_extractor.get_last_update_time
-    # not from: timestream_writer.get_earliest_writeable_time_for_table
     mock_metrics_extractor_from_provider.get_last_update_time.assert_not_called()
-    mock_timestream_writer.get_earliest_writeable_time_for_table.assert_not_called()
+    assert result["since_time"] == str_utc_datetime_to_datetime(
+        "2024-04-16 12:05:11.275000000"
+    )
 
     # no alerts sent (glue uses eventbridge for alerts)
     assert result["alerts_sent"] == False, "Alerts shouldn't be sent in this call"
@@ -268,11 +269,9 @@ def test_process_individual_resource_last_upd_time_from_timestream(
         result_ids=[],
     )
 
-    # Assert last_update_time is taken directly from arguments
-    # not from: metrics_extractor.get_last_update_time
-    # not from: timestream_writer.get_earliest_writeable_time_for_table
+    # last_update_time will be taken from Timestream corresponding table
     mock_metrics_extractor_from_provider.get_last_update_time.assert_called_once()
-    mock_timestream_writer.get_earliest_writeable_time_for_table.assert_not_called()
+    assert result["since_time"] == MOCKED_LAST_UPDATE_TIME
 
     # no alerts sent (glue uses eventbridge for alerts)
     assert result["alerts_sent"] == False, "Alerts shouldn't be sent in this call"
@@ -321,14 +320,62 @@ def test_process_individual_resource_no_last_upd_time(
             result_ids=[],
         )
 
-        # Assert last_update_time is taken directly from arguments
-        # not from: metrics_extractor.get_last_update_time
-        # not from: timestream_writer.get_earliest_writeable_time_for_table
+        # no last_update_time returned, the earliest writeable time should be used in this case
         mock_metrics_extractor_from_provider.get_last_update_time.assert_called_once()
         mock_timestream_writer.get_earliest_writeable_time_for_table.assert_called_once()
+        assert result["since_time"] == EARLIEST_WRITEABLE_TIME
 
         # no alerts sent (glue uses eventbridge for alerts)
         assert result["alerts_sent"] == False, "Alerts shouldn't be sent in this call"
+
+
+# testing successful flow when we last_update_time olrder the earliest writable time to Timestream
+# testing for "resource_name": "step-function1" with "last_update_time": "2024-04-15 12:05:11.275000000"
+def test_process_individual_resource_last_upd_time_earlier_writeable(
+    os_vars_values,
+    mock_settings,
+    mock_metrics_extractor_from_provider,
+    mock_timestream_writer,
+    mock_boto3_client_creator,
+):
+    (
+        settings_s3_path,
+        iam_role_name,
+        timestream_metrics_db_name,
+        alerts_event_bus_name,
+    ) = os_vars_values
+    monitored_environment_name = "env1"
+    resource_type = types.STEP_FUNCTIONS
+    resource_name = "step-function1"  # we have upd time for this glue job in LAST_UPDATE_TIMES_SAMPLE
+
+    boto3_client_creator = mock_boto3_client_creator
+    timestream_writer = mock_timestream_writer
+    timestream_metrics_table_name = "test_table_name"
+
+    result = process_individual_resource(
+        monitored_environment_name=monitored_environment_name,
+        resource_type=resource_type,
+        resource_name=resource_name,
+        boto3_client_creator=boto3_client_creator,
+        aws_client_name=SettingConfigs.RESOURCE_TYPES_LINKED_AWS_SERVICES[
+            resource_type
+        ],
+        timestream_writer=timestream_writer,
+        timestream_metrics_db_name=timestream_metrics_db_name,
+        timestream_metrics_table_name=timestream_metrics_table_name,
+        last_update_times=LAST_UPDATE_TIMES_SAMPLE,
+        alerts_event_bus_name=alerts_event_bus_name,
+        result_ids=[],
+    )
+
+    mock_metrics_extractor_from_provider.get_last_update_time.assert_not_called()
+    mock_timestream_writer.get_earliest_writeable_time_for_table.assert_called_once()
+
+    # since returned last_update_time is older then earlist writable time,
+    # the earliest writable time should be used for metrics extraction
+    assert result["since_time"] == EARLIEST_WRITEABLE_TIME
+    # no alerts sent (glue uses eventbridge for alerts)
+    assert result["alerts_sent"] == False, "Alerts shouldn't be sent in this call"
 
 
 # testing flow when specific resource type requires sending alerts


### PR DESCRIPTION
- in case the returned last_update_time for particular resource is older then the earliest writeable time, we will extract metrics since time which Timestream is able to accept so to prevent RejectedRecords Timestream error
- unit test to cover this additional logic was added