### PR TITLE
fix get_all_names for all services (paginator / next token)

### DIFF
--- a/src/lib/aws/emr_manager.py
+++ b/src/lib/aws/emr_manager.py
@@ -103,8 +103,16 @@ class EMRManager:
         """Get all EMR Serverless application names"""
 
         try:
-            response = self.sf_client.list_applications()
-            return [res["name"] for res in response.get("applications")]
+            paginator = self.sf_client.get_paginator("list_applications")
+            application_names = []
+
+            # Use paginator to iterate through all the pages
+            for page in paginator.paginate(maxResults=50):
+                application_names.extend(
+                    [res["name"] for res in page.get("applications", [])]
+                )
+
+            return application_names
 
         except Exception as e:
             error_message = f"Error getting a list of EMR applications: {e}"

--- a/src/lib/aws/lambda_manager.py
+++ b/src/lib/aws/lambda_manager.py
@@ -101,15 +101,6 @@ class LambdaManager:
             boto3.client("lambda") if lambda_client is None else lambda_client
         )
 
-    # def get_all_names(self, **kwargs):
-    #     try:
-    #         response = self.lambda_client.list_functions()
-    #         return [res["FunctionName"] for res in response.get("Functions")]
-
-    #     except Exception as e:
-    #         error_message = f"Error getting list of lambda functions : {e}"
-    #         raise LambdaManagerException(error_message)
-
     def get_all_names(self, **kwargs):
         try:
             paginator = self.lambda_client.get_paginator("list_functions")

--- a/src/lib/aws/lambda_manager.py
+++ b/src/lib/aws/lambda_manager.py
@@ -101,13 +101,30 @@ class LambdaManager:
             boto3.client("lambda") if lambda_client is None else lambda_client
         )
 
+    # def get_all_names(self, **kwargs):
+    #     try:
+    #         response = self.lambda_client.list_functions()
+    #         return [res["FunctionName"] for res in response.get("Functions")]
+
+    #     except Exception as e:
+    #         error_message = f"Error getting list of lambda functions : {e}"
+    #         raise LambdaManagerException(error_message)
+
     def get_all_names(self, **kwargs):
         try:
-            response = self.lambda_client.list_functions()
-            return [res["FunctionName"] for res in response.get("Functions")]
+            paginator = self.lambda_client.get_paginator("list_functions")
+            function_names = []
+
+            # Use paginator to iterate through all the pages
+            for page in paginator.paginate(MaxItems=100):
+                function_names.extend(
+                    [res["FunctionName"] for res in page.get("Functions", [])]
+                )
+
+            return function_names
 
         except Exception as e:
-            error_message = f"Error getting list of lambda functions : {e}"
+            error_message = f"Error getting list of lambda functions: {e}"
             raise LambdaManagerException(error_message)
 
     def get_log_group(self, lambda_function_name: str) -> str:


### PR DESCRIPTION
modified get_all_names for all services, so if result doesn't fit in one default page, it would use paginator or next token to retrieve full list.