### PR TITLE
Integration tests/purge cw logs lambdas

### DIFF
--- a/cdk/integration_testing_stand/stacks/testing_stand_stack.py
+++ b/cdk/integration_testing_stand/stacks/testing_stand_stack.py
@@ -491,6 +491,7 @@ def handler(event, context):
                         workflow_name=workflow.name,
                         type="ON_DEMAND",
                     )
+                    trigger_job_one.node.add_dependency(glue_job_tmp)
                     prev_job_name = job_name
                 else:  # second and other jobs in workflow
                     trigger_job_two = glue_old.CfnTrigger(
@@ -513,6 +514,7 @@ def handler(event, context):
                         ),
                         start_on_creation=True,
                     )
+                    trigger_job_two.node.add_dependency(glue_job_tmp)
 
     def create_glue_crawlers_resources(self, cfg_reader):
         def create_iam_role(meaning, flg_deny_create_table):

--- a/cdk/integration_testing_stand/stacks/testing_stand_stack.py
+++ b/cdk/integration_testing_stand/stacks/testing_stand_stack.py
@@ -385,7 +385,7 @@ def handler(event, context):
             self,
             "PurgeLogsLambdaRole",
             assumed_by=iam.ServicePrincipal("lambda.amazonaws.com"),
-            role_name=AWSNaming.IAMRole(self, "purge-cwlogs-lambda"),
+            role_name=AWSNaming.IAMRole(self, "purge-cw-logs-lambda"),
         )
 
         role.add_managed_policy(

--- a/cdk/integration_testing_stand/stacks/testing_stand_stack.py
+++ b/cdk/integration_testing_stand/stacks/testing_stand_stack.py
@@ -383,7 +383,7 @@ def handler(event, context):
             self,
             "PurgeLogsLambdaRole",
             assumed_by=iam.ServicePrincipal("lambda.amazonaws.com"),
-            role_name=AWSNaming.IAMRole(self, "purge-logs-lambda"),
+            role_name=AWSNaming.IAMRole(self, "purge-cwlogs-lambda"),
         )
 
         role.add_managed_policy(

--- a/src/lambda_inttests_purge_cloudwatch_logs.py
+++ b/src/lambda_inttests_purge_cloudwatch_logs.py
@@ -1,0 +1,40 @@
+import boto3
+import json
+import logging
+
+from lib.aws.lambda_manager import LambdaManager
+from lib.aws.cloudwatch_manager import CloudWatchManager
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def lambda_handler(event, context):
+    print("Received event: " + json.dumps(event))
+
+    try:
+        request_type = event["RequestType"]
+        lambda_function_names = event["ResourceProperties"]["lambda_function_names"]
+        if request_type == "Delete":
+            lman = LambdaManager()
+            cwman = CloudWatchManager()
+            for lambda_function_name in lambda_function_names:
+                log_group_name = lman.get_log_group(
+                    lambda_function_name=lambda_function_name
+                )
+                log_group_exists = cwman.log_group_exists(log_group_name)
+                if log_group_exists:
+                    logger.info(f"Purging log streams for {lambda_function_name = }")
+                    cwman.purge_log_streams(log_group_name=log_group_name)
+                    logger.info(f"Done.")
+                else:
+                    logger.info(
+                        f"Log group {log_group_name} doesn't exists. Skipping deletion of log streams."
+                    )
+
+        else:
+            print(f"{request_type = }, skipping log purge")
+
+    except Exception as e:
+        print("Error: ", str(e))
+        raise e  # Signal failure if an exception occurs


### PR DESCRIPTION
When integration tests infra is deleted, CloudWatch logs for testing stand lambdas are purged (so they won't result in fake error messages from previous executions)