### PR TITLE
Adding capabilities to use limited permission CDK exec role (instead of default one)

### DIFF
--- a/.github/actions/cdk-deploy/action.yml
+++ b/.github/actions/cdk-deploy/action.yml
@@ -24,10 +24,12 @@ runs:
         cd ${{ inputs.cdk-folder-name }}
 
         if [ -n "${{ inputs.cdk-bootstrap-qualifier }}" ]; then
+          echo "Using specific bootstrap qualifier: '${{ inputs.cdk-bootstrap-qualifier }}'"
           cdk deploy --context stage-name=${{ inputs.stage-name }} \
             --context "@aws-cdk/core:bootstrapQualifier=${{ inputs.cdk-bootstrap-qualifier }}" \
             --require-approval never
         else
+          echo "Using default bootstrap (CDKToolkit)."
           cdk deploy --context stage-name=${{ inputs.stage-name }} --require-approval never
         fi
         

--- a/.github/actions/cdk-deploy/action.yml
+++ b/.github/actions/cdk-deploy/action.yml
@@ -7,6 +7,12 @@ inputs:
   stage-name:  
     description: 'stage-name which is used as CDK context var'
     required: true
+  cdk-bootstrap-qualifier:
+    description: 'Optional bootstrap qualifier for CDK'
+    required: false
+    default: "" # Default value set to an empty string
+    # If cdk-bootstrap-qualifier is not set or passed as an empty_string - 
+    # runs cdk deploy command with default CDKToolkit, otherwise - using given alternative
 
 runs:
   using: "composite"
@@ -16,5 +22,12 @@ runs:
       run: |
         source venv/bin/activate      
         cd ${{ inputs.cdk-folder-name }}
-        cdk deploy --context stage-name=${{ inputs.stage-name }} --require-approval never
+
+        if [ -n "${{ inputs.cdk-bootstrap-qualifier }}" ]; then
+          cdk deploy --context stage-name=${{ inputs.stage-name }} \
+            --context "@aws-cdk/core:bootstrapQualifier=${{ inputs.cdk-bootstrap-qualifier }}" \
+            --require-approval never
+        else
+          cdk deploy --context stage-name=${{ inputs.stage-name }} --require-approval never
+        fi
         

--- a/.github/actions/cdk-destroy/action.yml
+++ b/.github/actions/cdk-destroy/action.yml
@@ -7,6 +7,12 @@ inputs:
   stage-name:  
     description: 'stage-name which is used as CDK context var'
     required: true
+  cdk-bootstrap-qualifier:
+    description: 'Optional bootstrap qualifier for CDK'
+    required: false
+    default: "" # Default value set to an empty string
+    # If cdk-bootstrap-qualifier is not set or passed as an empty_string - 
+    # runs cdk deploy command with default CDKToolkit, otherwise - using given alternative
 
 runs:
   using: "composite"
@@ -16,4 +22,11 @@ runs:
       run: |
         source venv/bin/activate      
         cd ${{ inputs.cdk-folder-name }}
-        cdk destroy --context stage-name=${{ inputs.stage-name }} --force
+
+        if [ -n "${{ inputs.cdk-bootstrap-qualifier }}" ]; then
+          cdk deploy --context stage-name=${{ inputs.stage-name }} \
+            --context "@aws-cdk/core:bootstrapQualifier=${{ inputs.cdk-bootstrap-qualifier }}" \
+            --require-approval never
+        else
+          cdk deploy --context stage-name=${{ inputs.stage-name }} --require-approval never
+        fi

--- a/.github/actions/cdk-destroy/action.yml
+++ b/.github/actions/cdk-destroy/action.yml
@@ -25,10 +25,10 @@ runs:
 
         if [ -n "${{ inputs.cdk-bootstrap-qualifier }}" ]; then
           echo "Using specific bootstrap qualifier: '${{ inputs.cdk-bootstrap-qualifier }}'"
-          cdk deploy --context stage-name=${{ inputs.stage-name }} \
+          cdk destroy --context stage-name=${{ inputs.stage-name }} \
             --context "@aws-cdk/core:bootstrapQualifier=${{ inputs.cdk-bootstrap-qualifier }}" \
             --require-approval never
         else
           echo "Using default bootstrap (CDKToolkit)."
-          cdk deploy --context stage-name=${{ inputs.stage-name }} --require-approval never
+          cdk destroy --context stage-name=${{ inputs.stage-name }} --require-approval never
         fi

--- a/.github/actions/cdk-destroy/action.yml
+++ b/.github/actions/cdk-destroy/action.yml
@@ -24,9 +24,11 @@ runs:
         cd ${{ inputs.cdk-folder-name }}
 
         if [ -n "${{ inputs.cdk-bootstrap-qualifier }}" ]; then
+          echo "Using specific bootstrap qualifier: '${{ inputs.cdk-bootstrap-qualifier }}'"
           cdk deploy --context stage-name=${{ inputs.stage-name }} \
             --context "@aws-cdk/core:bootstrapQualifier=${{ inputs.cdk-bootstrap-qualifier }}" \
             --require-approval never
         else
+          echo "Using default bootstrap (CDKToolkit)."
           cdk deploy --context stage-name=${{ inputs.stage-name }} --require-approval never
         fi

--- a/.github/actions/cdk-destroy/action.yml
+++ b/.github/actions/cdk-destroy/action.yml
@@ -27,8 +27,8 @@ runs:
           echo "Using specific bootstrap qualifier: '${{ inputs.cdk-bootstrap-qualifier }}'"
           cdk destroy --context stage-name=${{ inputs.stage-name }} \
             --context "@aws-cdk/core:bootstrapQualifier=${{ inputs.cdk-bootstrap-qualifier }}" \
-            --require-approval never
+            --force
         else
           echo "Using default bootstrap (CDKToolkit)."
-          cdk destroy --context stage-name=${{ inputs.stage-name }} --require-approval never
+          cdk destroy --context stage-name=${{ inputs.stage-name }} --force
         fi

--- a/.github/workflows/cdk_deployment_tests.yml
+++ b/.github/workflows/cdk_deployment_tests.yml
@@ -4,6 +4,7 @@ env:
   CDK_MONITORED_ENV_FOLDER: cdk/monitored_environment
   STAGE_NAME: devcdk
   SETTING_FOLDER_NAME: "tests/deployment-tests/settings"
+  CDK_BOOTSTRAP_QUALIFIER: ${{ vars.CDK_BOOTSTRAP_QUALIFIER }}
 permissions:
       id-token: write   # This is required for requesting the JWT
       contents: read    # This is required for actions/checkout    
@@ -19,6 +20,20 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
+
+      # checking if we have var CDK_BOOTSTRAP_QUALIFIER set in th git repo
+      # env.QUALIFIER is the result used in further cdk deploy/destroy commands
+      # set to qualifier is variable is set or an empty string otherwise
+      - name: Set CDK Bootstrap Qualifier
+        id: set-qualifier
+        run: |
+          if [[ -z "${{ env.CDK_BOOTSTRAP_QUALIFIER }}" ]]; then
+            echo "No CDK_QUALIFIER found. Defaulting to an empty string."
+            echo "QUALIFIER=" >> $GITHUB_ENV
+          else
+            echo "Using CDK_QUALIFIER: ${{ env.CDK_BOOTSTRAP_QUALIFIER }}"
+            echo "QUALIFIER=${{ env.CDK_BOOTSTRAP_QUALIFIER }}" >> $GITHUB_ENV
+          fi
 
       - name: Assume AWS Role
         uses: ./.github/actions/assume-aws-service-role-for-tests
@@ -43,21 +58,25 @@ jobs:
         with:
           cdk-folder-name: ${{ env.CDK_TOOLING_ENV_FOLDER }}
           stage-name: ${{ env.STAGE_NAME }}
+          cdk-bootstrap-qualifier: ${{ env.QUALIFIER }}
 
       - name: deploy monitoring env via CDK
         uses: ./.github/actions/cdk-deploy
         with:
           cdk-folder-name: ${{ env.CDK_MONITORED_ENV_FOLDER }}
           stage-name: ${{ env.STAGE_NAME }}
+          cdk-bootstrap-qualifier: ${{ env.QUALIFIER }}
 
       - name: destroy monitoring env via CDK
         uses: ./.github/actions/cdk-destroy
         with:
           cdk-folder-name: ${{ env.CDK_MONITORED_ENV_FOLDER }}
           stage-name: ${{ env.STAGE_NAME }}
+          cdk-bootstrap-qualifier: ${{ env.QUALIFIER }}
   
       - name: destroy tooling env via CDK
         uses: ./.github/actions/cdk-destroy
         with:
           cdk-folder-name: ${{ env.CDK_TOOLING_ENV_FOLDER }}
           stage-name: ${{ env.STAGE_NAME }}
+          cdk-bootstrap-qualifier: ${{ env.QUALIFIER }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -2,8 +2,6 @@ name: Unit tests
 env:
     AWS_DEFAULT_REGION: dummy
     TESTS_FOLDER: tests/unit-tests
-    CDK_QUALIFIER: ${{ vars.CDK_QUALIFIER }}
-
 run-name: unit tests
 on:
   push:
@@ -14,35 +12,22 @@ jobs:
   unit-testing:
     runs-on: ubuntu-latest
     steps:
-      - name: Set CDK Qualifier
-        id: set-qualifier
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Setup Python Virtual Environment
+        id: setup-venv
+        uses: ./.github/actions/setup-venv
+
+      - name: Install Python requirements
         run: |
-          if [[ -z "${{ env.CDK_QUALIFIER }}" ]]; then
-            echo "No CDK_QUALIFIER found. Defaulting to an empty string."
-            echo "QUALIFIER=" >> $GITHUB_ENV
-          else
-            echo "Using CDK_QUALIFIER: ${{ env.CDK_QUALIFIER }}"
-            echo "QUALIFIER=${{ env.CDK_QUALIFIER }}" >> $GITHUB_ENV
-          fi
+          venv/bin/pip3 install -r requirements.txt
+          venv/bin/pip3 install -r requirements-test.txt
 
-
-
-      # - name: Check out repository code
-      #   uses: actions/checkout@v4
-
-      # - name: Setup Python Virtual Environment
-      #   id: setup-venv
-      #   uses: ./.github/actions/setup-venv
-
-      # - name: Install Python requirements
-      #   run: |
-      #     venv/bin/pip3 install -r requirements.txt
-      #     venv/bin/pip3 install -r requirements-test.txt
-
-      # # Copying configuration files, so they are present. The files' content is not important for unit tests
-      # - name: Copy sample settings
-      #   run: mkdir -p config/settings && cp ${{ env.TESTS_FOLDER }}/settings/main_tests/*.json config/settings/
+      # Copying configuration files, so they are present. The files' content is not important for unit tests
+      - name: Copy sample settings
+        run: mkdir -p config/settings && cp ${{ env.TESTS_FOLDER }}/settings/main_tests/*.json config/settings/
                   
-      # - name: Run unit tests
-      #   run: |
-      #     venv/bin/pytest ${{ env.TESTS_FOLDER }}
+      - name: Run unit tests
+        run: |
+          venv/bin/pytest ${{ env.TESTS_FOLDER }}

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -2,6 +2,8 @@ name: Unit tests
 env:
     AWS_DEFAULT_REGION: dummy
     TESTS_FOLDER: tests/unit-tests
+    CDK_QUALIFIER: ${{ vars.CDK_QUALIFIER }}
+
 run-name: unit tests
 on:
   push:
@@ -12,22 +14,35 @@ jobs:
   unit-testing:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out repository code
-        uses: actions/checkout@v4
-
-      - name: Setup Python Virtual Environment
-        id: setup-venv
-        uses: ./.github/actions/setup-venv
-
-      - name: Install Python requirements
+      - name: Set CDK Qualifier
+        id: set-qualifier
         run: |
-          venv/bin/pip3 install -r requirements.txt
-          venv/bin/pip3 install -r requirements-test.txt
+          if [[ -z "${{ env.CDK_QUALIFIER }}" ]]; then
+            echo "No CDK_QUALIFIER found. Defaulting to an empty string."
+            echo "QUALIFIER=" >> $GITHUB_ENV
+          else
+            echo "Using CDK_QUALIFIER: ${{ env.CDK_QUALIFIER }}"
+            echo "QUALIFIER=${{ env.CDK_QUALIFIER }}" >> $GITHUB_ENV
+          fi
 
-      # Copying configuration files, so they are present. The files' content is not important for unit tests
-      - name: Copy sample settings
-        run: mkdir -p config/settings && cp ${{ env.TESTS_FOLDER }}/settings/main_tests/*.json config/settings/
+
+
+      # - name: Check out repository code
+      #   uses: actions/checkout@v4
+
+      # - name: Setup Python Virtual Environment
+      #   id: setup-venv
+      #   uses: ./.github/actions/setup-venv
+
+      # - name: Install Python requirements
+      #   run: |
+      #     venv/bin/pip3 install -r requirements.txt
+      #     venv/bin/pip3 install -r requirements-test.txt
+
+      # # Copying configuration files, so they are present. The files' content is not important for unit tests
+      # - name: Copy sample settings
+      #   run: mkdir -p config/settings && cp ${{ env.TESTS_FOLDER }}/settings/main_tests/*.json config/settings/
                   
-      - name: Run unit tests
-        run: |
-          venv/bin/pytest ${{ env.TESTS_FOLDER }}
+      # - name: Run unit tests
+      #   run: |
+      #     venv/bin/pytest ${{ env.TESTS_FOLDER }}

--- a/cdk/README.md
+++ b/cdk/README.md
@@ -1,10 +1,31 @@
+# CDK components
+
+## This Folder Content
 
 This folder contains subfolders with CDK application:
 
-Core SALMON components:  
-1. tooling_environment
-2. monitoring_environment
+**Core SALMON components:**
 
-Optional components (if you want to run automated integration tests):  
-3. github_actions_resources - resources needed to run GitHub actions workflows (namely, IAM service role).
-4. (to be migrated here) integration tests: testing stand + AWS resources required for tests execution.
+1. `tooling_environment` - CDK app to deploy tooling environment.
+2. `monitoring_environment` - CDK app to deploy monitored environment.
+
+**Optional component** (CDK customization):
+
+1. `salmon_cdk_cloudformation_exec_policy.yaml` - CloudFormation template to create custom policy for CDK deployments (less-privileged than the default one, containing minimum sufficient permission for SALMON).
+
+Please see section below for details.
+
+**Optional components** (integration / deployment tests):  
+
+The following components are required if you are a contributor to SALMON project and you want to execute integration/deployment tests before creating a Pull Request.
+
+1. `github_actions_resources` - resources needed to run GitHub actions workflows (namely, IAM service role).
+2. `integration_testing_stand`: testing stand + AWS resources required for tests execution.
+
+## Limiting CDK execution role privileges
+
+<<todo>>
+
+```bash
+aws cloudformation deploy --template-file salmon_cdk_cloudformation_exec_policy.yaml --stack-name cf-salmon-cdk-cloudformation-exec-policy-all --capabilities CAPABILITY_NAMED_IAM
+```

--- a/cdk/README.md
+++ b/cdk/README.md
@@ -1,23 +1,23 @@
 # CDK components
 
-## This Folder Content
+## Overview
 
-This folder contains subfolders with CDK application:
+This folder contains CDK applications and related resources for deploying and managing the **SALMON** project. It includes both core components for production environments and optional components for customization and testing.
 
 **Core SALMON components:**
 
-1. `tooling_environment` - CDK app to deploy tooling environment.
-2. `monitoring_environment` - CDK app to deploy monitored environment.
+1. `tooling_environment` - CDK application to deploy the tooling environment.
+2. `monitoring_environment` - CDK application to deploy the monitored environment.
 
 **Optional component** (CDK customization):
 
-1. `salmon_cdk_cloudformation_exec_policy.yaml` - CloudFormation template to create custom policy for CDK deployments (less-privileged than the default one, containing minimum sufficient permission for SALMON).
+1. `salmon_cdk_cloudformation_exec_policy.yaml` - CloudFormation template to create a custom policy for CDK deployments. This policy is less privileged than the default AdministratorAccess and contains only the permissions sufficient for deploying SALMON.
 
-For more details, please see [Limiting AWS CDK permissions](/docs/limit_cdk_permissions.md)
+    For details, refer to [Limiting AWS CDK permissions](/docs/limit_cdk_permissions.md)
 
 **Optional components** (integration / deployment tests):  
 
-The following components are required if you are a contributor to SALMON project and you want to execute integration/deployment tests before creating a Pull Request.
+The following components are required if you are contributing to the SALMON project and need to execute integration or deployment tests before creating a pull request:
 
-1. `github_actions_resources` - resources needed to run GitHub actions workflows (namely, IAM service role).
-2. `integration_testing_stand`: testing stand + AWS resources required for tests execution.
+1. `github_actions_resources` - resources needed to run GitHub Actions workflows (e.g., IAM service role).
+2. `integration_testing_stand`: testing stand and AWS resources required for executing tests.

--- a/cdk/README.md
+++ b/cdk/README.md
@@ -13,7 +13,7 @@ This folder contains subfolders with CDK application:
 
 1. `salmon_cdk_cloudformation_exec_policy.yaml` - CloudFormation template to create custom policy for CDK deployments (less-privileged than the default one, containing minimum sufficient permission for SALMON).
 
-Please see section below for details.
+For more details, please see [Limiting AWS CDK permissions](/docs/limit_cdk_permissions.md)
 
 **Optional components** (integration / deployment tests):  
 
@@ -21,11 +21,3 @@ The following components are required if you are a contributor to SALMON project
 
 1. `github_actions_resources` - resources needed to run GitHub actions workflows (namely, IAM service role).
 2. `integration_testing_stand`: testing stand + AWS resources required for tests execution.
-
-## Limiting CDK execution role privileges
-
-<<todo>>
-
-```bash
-aws cloudformation deploy --template-file salmon_cdk_cloudformation_exec_policy.yaml --stack-name cf-salmon-cdk-cloudformation-exec-policy-all --capabilities CAPABILITY_NAMED_IAM
-```

--- a/cdk/salmon_cdk_cloudformation_exec_policy.yaml
+++ b/cdk/salmon_cdk_cloudformation_exec_policy.yaml
@@ -9,6 +9,7 @@ Resources:
         Statement:
           - Effect: Allow
             Action:
+              - cloudformation:*    # For Nested Stacks (InfraToolingMainStack)
               - ec2:*               # ToolingGrafana
               - emr-serverless:*    # ToolingAlerting, Monitored
               - events:*            # ToolingAlerting, ToolingMonitoring, Monitored
@@ -21,6 +22,7 @@ Resources:
               - secretsmanager:*    # ToolingCommon, ToolingGrafana
               - ses:*               # ToolingCommon
               - sns:*               # ToolingAlerting, ToolingCommon, ToolingMonitoring
+              - ssm:*               # Required by CDK itself (ssm:GetParameters)
               - sqs:*               # ToolingAlerting, ToolingCommon, ToolingMonitoring
               - states:*            # Monitored
               - timestream:*        # ToolingCommon, ToolingGrafana, ToolingMonitoring

--- a/cdk/salmon_cdk_cloudformation_exec_policy.yaml
+++ b/cdk/salmon_cdk_cloudformation_exec_policy.yaml
@@ -11,17 +11,17 @@ Resources:
             Action:
               - ec2:*               # ToolingGrafana
               - emr-serverless:*    # ToolingAlerting
-              - events:*            # ToolingAlerting
-              - iam:*               # ToolingAlerting, ToolingCommon, ToolingGrafana
-              - kms:*               # ToolingCommon, ToolingGrafana
-              - lambda:*            # ToolingAlerting, ToolingCommon
+              - events:*            # ToolingAlerting, ToolingMonitoring
+              - iam:*               # ToolingAlerting, ToolingCommon, ToolingGrafana, ToolingMonitoring
+              - kms:*               # ToolingCommon, ToolingGrafana, ToolingMonitoring
+              - lambda:*            # ToolingAlerting, ToolingCommon, ToolingMonitoring
               - logs:*              # ToolingAlerting, ToolingCommon, ToolingGrafana
-              - s3:*                # ToolingAlerting, ToolingCommon, ToolingGrafana
+              - s3:*                # ToolingAlerting, ToolingCommon, ToolingGrafana, ToolingMonitoring
               - secretsmanager:*    # ToolingCommon, ToolingGrafana
               - ses:*               # ToolingCommon
-              - sns:*               # ToolingAlerting, ToolingCommon
-              - sqs:*               # ToolingAlerting, ToolingCommon
-              - timestream:*        # ToolingCommon, ToolingGrafana
+              - sns:*               # ToolingAlerting, ToolingCommon, ToolingMonitoring
+              - sqs:*               # ToolingAlerting, ToolingCommon, ToolingMonitoring
+              - timestream:*        # ToolingCommon, ToolingGrafana, ToolingMonitoring
             Resource: "*"
 
 

--- a/cdk/salmon_cdk_cloudformation_exec_policy.yaml
+++ b/cdk/salmon_cdk_cloudformation_exec_policy.yaml
@@ -10,8 +10,13 @@ Resources:
           - Effect: Allow
             Action:
               - s3:*
+              - sns:*
+              - sqs:*
               - lambda:*
+              - logs:*
               - iam:*
+              - events:*
+              - emr-serverless:*
             Resource: "*"
           - Effect: Allow
             Action:

--- a/cdk/salmon_cdk_cloudformation_exec_policy.yaml
+++ b/cdk/salmon_cdk_cloudformation_exec_policy.yaml
@@ -17,13 +17,12 @@ Resources:
               - iam:*
               - events:*
               - emr-serverless:*
+              - kms:*
+              - timestream:*
+              - ses:*
+              - secretsmanager:*
             Resource: "*"
-          - Effect: Allow
-            Action:
-              - logs:CreateLogGroup
-              - logs:PutRetentionPolicy
-              - logs:DeleteLogGroup
-            Resource: "*"
+
 
 Outputs:
   PolicyArn:

--- a/cdk/salmon_cdk_cloudformation_exec_policy.yaml
+++ b/cdk/salmon_cdk_cloudformation_exec_policy.yaml
@@ -9,18 +9,19 @@ Resources:
         Statement:
           - Effect: Allow
             Action:
-              - s3:*
-              - sns:*
-              - sqs:*
-              - lambda:*
-              - logs:*
-              - iam:*
-              - events:*
-              - emr-serverless:*
-              - kms:*
-              - timestream:*
-              - ses:*
-              - secretsmanager:*
+              - ec2:*               # ToolingGrafana
+              - emr-serverless:*    # ToolingAlerting
+              - events:*            # ToolingAlerting
+              - iam:*               # ToolingAlerting, ToolingCommon, ToolingGrafana
+              - kms:*               # ToolingCommon, ToolingGrafana
+              - lambda:*            # ToolingAlerting, ToolingCommon
+              - logs:*              # ToolingAlerting, ToolingCommon, ToolingGrafana
+              - s3:*                # ToolingAlerting, ToolingCommon, ToolingGrafana
+              - secretsmanager:*    # ToolingCommon, ToolingGrafana
+              - ses:*               # ToolingCommon
+              - sns:*               # ToolingAlerting, ToolingCommon
+              - sqs:*               # ToolingAlerting, ToolingCommon
+              - timestream:*        # ToolingCommon, ToolingGrafana
             Resource: "*"
 
 

--- a/cdk/salmon_cdk_cloudformation_exec_policy.yaml
+++ b/cdk/salmon_cdk_cloudformation_exec_policy.yaml
@@ -10,17 +10,19 @@ Resources:
           - Effect: Allow
             Action:
               - ec2:*               # ToolingGrafana
-              - emr-serverless:*    # ToolingAlerting
-              - events:*            # ToolingAlerting, ToolingMonitoring
-              - iam:*               # ToolingAlerting, ToolingCommon, ToolingGrafana, ToolingMonitoring
+              - emr-serverless:*    # ToolingAlerting, Monitored
+              - events:*            # ToolingAlerting, ToolingMonitoring, Monitored
+              - glue:*              # Monitored
+              - iam:*               # ToolingAlerting, ToolingCommon, ToolingGrafana, ToolingMonitoring, Monitored
               - kms:*               # ToolingCommon, ToolingGrafana, ToolingMonitoring
-              - lambda:*            # ToolingAlerting, ToolingCommon, ToolingMonitoring
-              - logs:*              # ToolingAlerting, ToolingCommon, ToolingGrafana
+              - lambda:*            # ToolingAlerting, ToolingCommon, ToolingMonitoring, Monitored
+              - logs:*              # ToolingAlerting, ToolingCommon, ToolingGrafana, Monitored
               - s3:*                # ToolingAlerting, ToolingCommon, ToolingGrafana, ToolingMonitoring
               - secretsmanager:*    # ToolingCommon, ToolingGrafana
               - ses:*               # ToolingCommon
               - sns:*               # ToolingAlerting, ToolingCommon, ToolingMonitoring
               - sqs:*               # ToolingAlerting, ToolingCommon, ToolingMonitoring
+              - states:*            # Monitored
               - timestream:*        # ToolingCommon, ToolingGrafana, ToolingMonitoring
             Resource: "*"
 

--- a/cdk/salmon_cdk_cloudformation_exec_policy.yaml
+++ b/cdk/salmon_cdk_cloudformation_exec_policy.yaml
@@ -1,0 +1,26 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  CdkDeployPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: policy-salmon-cdk-cloudformation-exec-all
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:*
+              - lambda:*
+              - iam:*
+            Resource: "*"
+          - Effect: Allow
+            Action:
+              - logs:CreateLogGroup
+              - logs:PutRetentionPolicy
+              - logs:DeleteLogGroup
+            Resource: "*"
+
+Outputs:
+  PolicyArn:
+    Description: "The ARN of the IAM Policy policy-salmon-cdk-cloudformation-exec-all"
+    Value: !Ref CdkDeployPolicy

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -58,3 +58,7 @@ A: Yes, you can configure email alerts to be sent to a Slack channel by followin
     ]
 }                 
 ```
+
+**Q: My company's policy doesn't allow to creating IAM roles with AdministratorAccess privilege, which CDK bootstrap does by default. Is there a workaround?**
+
+A: Yes, you can bootstrap AWS CDK with less-privileged IAM Role. Please see [Limiting AWS CDK permissions](/docs/limit_cdk_permissions.md) for details.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -59,6 +59,6 @@ A: Yes, you can configure email alerts to be sent to a Slack channel by followin
 }                 
 ```
 
-**Q: My company's policy doesn't allow to creating IAM roles with AdministratorAccess privilege, which CDK bootstrap does by default. Is there a workaround?**
+**Q: My company's policy prohibits creating IAM roles with AdministratorAccess privileges, which CDK bootstrap creates by default. Is there a workaround?**
 
-A: Yes, you can bootstrap AWS CDK with less-privileged IAM Role. Please see [Limiting AWS CDK permissions](/docs/limit_cdk_permissions.md) for details.
+A: Yes, you can bootstrap AWS CDK with a custom IAM policy that limits the privileges of the CloudFormation execution role. This allows you to comply with your company’s security policies while still using CDK. For detailed instructions, refer to [Limiting AWS CDK permissions](/docs/limit_cdk_permissions.md).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -14,6 +14,8 @@ you will need to recreate IAM Role in your monitored environment which is done b
 
 Data pipeline events which happen between step #3 and #4 in this specific monitored environment won't be recorded.
 
+---
+
 **Q: Can I use Slack to receive notifications?**
 
 A: Yes, you can configure email alerts to be sent to a Slack channel by following these steps:
@@ -58,6 +60,8 @@ A: Yes, you can configure email alerts to be sent to a Slack channel by followin
     ]
 }                 
 ```
+
+---
 
 **Q: My company's policy prohibits creating IAM roles with AdministratorAccess privileges, which CDK bootstrap creates by default. Is there a workaround?**
 

--- a/docs/limit_cdk_permissions.md
+++ b/docs/limit_cdk_permissions.md
@@ -1,8 +1,83 @@
 
-# Limiting CDK execution role privileges
+# Limiting CDK Execution Role Privileges
 
-<<todo>>
+By default, the `cdk bootstrap` command in AWS CDK creates a CloudFormation execution role with AdministratorAccess privileges. In environments where such a high level of access is unacceptable, it is possible to limit these privileges. This document describes how to configure a CDK bootstrap environment with restricted permissions tailored for the SALMON project.
+
+## Using a Custom IAM Policy for CDK Bootstrap
+
+The SALMON repository includes an IAM policy with permissions sufficient to deploy the project. You can instruct CDK to use this policy instead of the default. Follow these steps to set up a restricted CDK bootstrap.
+
+### 1. Create a Custom CDK Cloudformation Execution Policy
+
+Navigate to `/cdk` folder in this repo and deploy the custom policy using the following command:
 
 ```bash
 aws cloudformation deploy --template-file salmon_cdk_cloudformation_exec_policy.yaml --stack-name cf-salmon-cdk-cloudformation-exec-policy-all --capabilities CAPABILITY_NAMED_IAM
 ```
+
+After deployment, note the `PolicyArn` from the `cf-salmon-cdk-cloudformation-exec-policy-all` stack outputs in the **CloudFormation console**.
+
+### 2. Create CDK Bootstrap with Limited Permissions
+
+Use the custom policy to bootstrap the CDK environment with the following command:
+
+```bash
+cdk bootstrap --cloudformation-execution-policies <<policy_arn>>
+```
+
+Replace <<policy_arn>> with the `PolicyArn` from the previous step.
+
+### 3. Verify the Configuration
+
+To verify the permissions assigned to the CDK IAM role:
+
+1. Navigate to the **CloudFormation Console** and locate the `CDKToolkit` stack.
+2. Open the **Resources** tab and find the resource with the logical ID `CloudFormationExecutionRole`.
+3. Click on the role to review its permissions, ensuring it no longer uses AdministratorAccess and adheres to the custom policy.
+
+## Handling Conflicts with an Existing CDK Bootstrap
+
+In some cases, an existing CDK bootstrap in the same AWS account/region may already be used by other projects. To avoid conflicts, you can create an alternative bootstrap identified by a unique qualifier.
+
+### Prerequisite
+
+Ensure you have created a policy as demonstrated in Step 1 of the previous section.
+
+### 1. Create an Isolated CDK Bootstrap
+
+Run the following command to create a separate bootstrap stack:
+
+```bash
+cdk bootstrap --qualifier <<your_qualifier_name>> --cloudformation-execution-policies <<put created policy Arn here>> --toolkit-stack-name <<your_stack_name>>
+```
+
+Replace placeholders:
+
+- **your_qualifier_name**: A unique string (up to 10 characters) to identify this bootstrap. It will be used when running CDK commands. You can use `salmon`, for example.
+- **your_stack_name**: A custom name for the bootstrap CloudFormation stack. For example, use CDKToolkitSalmon instead of the default CDKToolkit.
+
+### 2. Using the Custom CDK Bootstrap for Deployments
+
+To use the custom bootstrap during deployment, specify the qualifier using CDK context:
+
+```bash
+cdk deploy -c "@aws-cdk/core:bootstrapQualifier=<<your_qualifier_name>>" --context stage-name=<<you_stage_name>>
+```
+
+Replace placeholders:
+
+- **your_qualifier_name** with the name of the qualifier you used during the bootstrap process.
+- **you_stage_name** with the Salmon's stage-name.
+
+## Additional consideration if you plan to contribute to Salmon project
+
+In order to check your changes before creating a pull request, it's recommended to run Integration and Deployment tests.
+Deployment tests should preferably be executed with limited-privileged CDK Bootstrap.
+In order to do this:
+
+1. **Create a Separate Bootstrap**: Follow the steps outlined in the previous section to create an isolated bootstrap.
+2. **Set a GitHub Repository Variable**:
+   - Name: CDK_BOOTSTRAP_QUALIFIER
+   - Value: The qualifier name you created (e.g., salmon).
+3. **Run Deployment Tests**:
+   - The deployment tests will automatically use the value of CDK_BOOTSTRAP_QUALIFIER to select the correct bootstrap.

--- a/docs/limit_cdk_permissions.md
+++ b/docs/limit_cdk_permissions.md
@@ -1,0 +1,8 @@
+
+# Limiting CDK execution role privileges
+
+<<todo>>
+
+```bash
+aws cloudformation deploy --template-file salmon_cdk_cloudformation_exec_policy.yaml --stack-name cf-salmon-cdk-cloudformation-exec-policy-all --capabilities CAPABILITY_NAMED_IAM
+```


### PR DESCRIPTION
1. created IAM policy to replace default AdministratorAccess policy for CDK execution role
2. updated / added documentation on how to create and use this policy
3. modified CDK Deployment tests workflow to make sure it always uses "limited" policy

It doesn't make sense to apply policy to integration test, as those are not customer-related artifacts.