### PR TITLE
update kms removal policy so the key is deleted in 7 days (min period)

### DIFF
--- a/cdk/tooling_environment/stacks/infra_tooling_common_stack.py
+++ b/cdk/tooling_environment/stacks/infra_tooling_common_stack.py
@@ -95,7 +95,7 @@ class InfraToolingCommonStack(NestedStack):
             "salmonTimestreamKMSKey",
             alias=AWSNaming.KMSKey(self, "timestream"),
             description="Key that protects Timestream data",
-            pending_window=7,
+            pending_window=Duration.days(7),
             removal_policy=RemovalPolicy.DESTROY,
         )
         timestream_storage = timestream.CfnDatabase(


### PR DESCRIPTION
- https://docs.aws.amazon.com/kms/latest/developerguide/deleting-keys.html
- AWS KMS requires to set a waiting period of 7 – 30 days before AWS KMS deletes a CMK that has been removed from a CloudFormation stack
- The default period (30 days) reduced to 7 days.
- Deployment tests: https://github.com/Soname-Solutions/salmon/actions/runs/12083639248/job/33697187963
- Deletion scheduled in 7 days as expected
![image](https://github.com/user-attachments/assets/94bca064-e123-4e55-b931-2fc92c88e0a7)
