### PR TITLE
metrics storage refactor. step3

### DIFF
--- a/cdk/integration_testing_stand/stacks/testing_stand_stack.py
+++ b/cdk/integration_testing_stand/stacks/testing_stand_stack.py
@@ -128,7 +128,7 @@ class TestingStandStack(Stack):
         lambda_function = _lambda.Function(
             self,
             "LambdaForwardToSQS",
-            runtime=_lambda.Runtime.PYTHON_3_11,
+            runtime=_lambda.Runtime.PYTHON_3_13,
             function_name=AWSNaming.LambdaFunction(self, "inttest-to-dynamo"),
             handler="index.handler",
             code=_lambda.Code.from_inline(
@@ -375,7 +375,7 @@ def handler(event, context):
                 ),
                 handler=f"{lambda_meaning}.lambda_handler",
                 timeout=Duration.seconds(30),
-                runtime=lambda_.Runtime.PYTHON_3_11,
+                runtime=lambda_.Runtime.PYTHON_3_13,
                 role=lambda_role,
                 retry_attempts=retry_attempts,
             )
@@ -424,7 +424,7 @@ def handler(event, context):
         purge_logs_function = _lambda.Function(
             self,
             "PurgeLogsFunction",
-            runtime=_lambda.Runtime.PYTHON_3_11,
+            runtime=_lambda.Runtime.PYTHON_3_13,
             handler="lambda_inttests_purge_cloudwatch_logs.lambda_handler",
             timeout=Duration.minutes(10),
             role=role,

--- a/cdk/monitored_environment/stacks/infra_monitored_stack.py
+++ b/cdk/monitored_environment/stacks/infra_monitored_stack.py
@@ -47,6 +47,15 @@ class InfraMonitoredStack(Stack):
             assumed_by=iam.ServicePrincipal("events.amazonaws.com"),
         )
 
+        # Add the AccountPrincipal permission to the assume role policy
+        cross_account_bus_role.assume_role_policy.add_statements(
+            iam.PolicyStatement(
+                effect=iam.Effect.ALLOW,
+                actions=["sts:AssumeRole"],
+                principals=[iam.AccountPrincipal(self.tooling_account_id)],
+            )
+        )
+
         cross_account_event_bus_name = AWSNaming.EventBus(
             self, CDKResourceNames.EVENTBUS_ALERTING
         )
@@ -58,9 +67,6 @@ class InfraMonitoredStack(Stack):
                 effect=iam.Effect.ALLOW,
                 resources=[cross_account_event_bus_arn],
             )
-        )
-        cross_account_bus_role.grant_assume_role(
-            iam.AccountPrincipal(self.tooling_account_id)
         )
 
         return cross_account_bus_role, cross_account_event_bus_arn

--- a/cdk/tooling_environment/stacks/infra_tooling_alerting_stack.py
+++ b/cdk/tooling_environment/stacks/infra_tooling_alerting_stack.py
@@ -242,7 +242,7 @@ class InfraToolingAlertingStack(NestedStack):
             ),
             handler="lambda_alerting.lambda_handler",
             timeout=Duration.seconds(120),
-            runtime=lambda_.Runtime.PYTHON_3_11,
+            runtime=lambda_.Runtime.PYTHON_3_13,
             environment={
                 "SETTINGS_S3_PATH": f"s3://{settings_bucket.bucket_name}/settings/",
                 "NOTIFICATION_QUEUE_URL": notification_queue.queue_url,

--- a/cdk/tooling_environment/stacks/infra_tooling_common_stack.py
+++ b/cdk/tooling_environment/stacks/infra_tooling_common_stack.py
@@ -251,7 +251,7 @@ class InfraToolingCommonStack(NestedStack):
             },
             layers=[powertools_layer],
             timeout=Duration.seconds(60),
-            runtime=lambda_.Runtime.PYTHON_3_11,
+            runtime=lambda_.Runtime.PYTHON_3_13,
             role=notification_lambda_role,
             retry_attempts=2,
             # no destinations configuration because destinations do not support SQS lambda event source

--- a/cdk/tooling_environment/stacks/infra_tooling_monitoring_stack.py
+++ b/cdk/tooling_environment/stacks/infra_tooling_monitoring_stack.py
@@ -291,7 +291,7 @@ class InfraToolingMonitoringStack(NestedStack):
             environment={
                 "SETTINGS_S3_PATH": f"s3://{settings_bucket.bucket_name}/settings/",
                 "IAMROLE_MONITORED_ACC_EXTRACT_METRICS": extr_metr_role_name,
-                "TIMESTREAM_METRICS_DB_NAME": timestream_database_name,
+                "METRICS_DB_NAME": timestream_database_name,
                 "ALERTS_EVENT_BUS_NAME": alerting_bus.event_bus_name,
             },
             role=extract_metrics_lambda_role,
@@ -326,7 +326,7 @@ class InfraToolingMonitoringStack(NestedStack):
                 "SETTINGS_S3_PATH": f"s3://{settings_bucket.bucket_name}/settings/",
                 "IAMROLE_MONITORED_ACC_EXTRACT_METRICS": extr_metr_role_name,
                 "LAMBDA_EXTRACT_METRICS_NAME": extract_metrics_lambda.function_name,
-                "TIMESTREAM_METRICS_DB_NAME": timestream_database_name,
+                "METRICS_DB_NAME": timestream_database_name,
             },
             role=extract_metrics_lambda_role,
             layers=[powertools_layer],
@@ -457,7 +457,7 @@ class InfraToolingMonitoringStack(NestedStack):
                     self, CDKResourceNames.IAMROLE_MONITORED_ACC_EXTRACT_METRICS
                 ),
                 "NOTIFICATION_QUEUE_URL": notification_queue.queue_url,
-                "TIMESTREAM_METRICS_DB_NAME": timestream_database_name,
+                "METRICS_DB_NAME": timestream_database_name,
                 "DIGEST_REPORT_PERIOD_HOURS": str(digest_report_period_hours),
             },
             role=digest_lambda_role,

--- a/cdk/tooling_environment/stacks/infra_tooling_monitoring_stack.py
+++ b/cdk/tooling_environment/stacks/infra_tooling_monitoring_stack.py
@@ -287,7 +287,7 @@ class InfraToolingMonitoringStack(NestedStack):
             ),
             handler="lambda_extract_metrics.lambda_handler",
             timeout=Duration.seconds(900),
-            runtime=lambda_.Runtime.PYTHON_3_11,
+            runtime=lambda_.Runtime.PYTHON_3_13,
             environment={
                 "SETTINGS_S3_PATH": f"s3://{settings_bucket.bucket_name}/settings/",
                 "IAMROLE_MONITORED_ACC_EXTRACT_METRICS": extr_metr_role_name,
@@ -321,7 +321,7 @@ class InfraToolingMonitoringStack(NestedStack):
             ),
             handler="lambda_extract_metrics_orch.lambda_handler",
             timeout=Duration.seconds(900),
-            runtime=lambda_.Runtime.PYTHON_3_11,
+            runtime=lambda_.Runtime.PYTHON_3_13,
             environment={
                 "SETTINGS_S3_PATH": f"s3://{settings_bucket.bucket_name}/settings/",
                 "IAMROLE_MONITORED_ACC_EXTRACT_METRICS": extr_metr_role_name,
@@ -450,7 +450,7 @@ class InfraToolingMonitoringStack(NestedStack):
             ),
             handler="lambda_digest.lambda_handler",
             timeout=Duration.seconds(900),
-            runtime=lambda_.Runtime.PYTHON_3_11,
+            runtime=lambda_.Runtime.PYTHON_3_13,
             environment={
                 "SETTINGS_S3_PATH": f"s3://{settings_bucket.bucket_name}/settings/",
                 "IAMROLE_MONITORED_ACC_EXTRACT_METRICS": AWSNaming.IAMRole(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aws-cdk-lib==2.103.1
+aws-cdk-lib==2.174.1
 constructs>=10.0.0,<11.0.0
 jsonschema
 boto3

--- a/src/lambda_digest.py
+++ b/src/lambda_digest.py
@@ -200,8 +200,8 @@ def lambda_handler(event, context):
     for resource_type in SettingConfigs.RESOURCE_TYPES:
         # ceate an digest extractor for a specific resource type
         digest_extractor = DigestDataExtractorProvider.get_digest_provider(
-            metrics_storage=metrics_storage,
             resource_type=resource_type,
+            metrics_storage=metrics_storage,
         )
         logger.info(f"Created digest extractor of type {type(digest_extractor)}")
         query = digest_extractor.get_query(digest_start_time, digest_end_time)

--- a/src/lambda_digest.py
+++ b/src/lambda_digest.py
@@ -180,7 +180,7 @@ def lambda_handler(event, context):
     iam_role_name = os.environ["IAMROLE_MONITORED_ACC_EXTRACT_METRICS"]
     notification_queue_url = os.environ["NOTIFICATION_QUEUE_URL"]
     metrics_storage_type = MetricsStorageTypes.AWS_TIMESTREAM
-    metrics_db_name = os.environ["TIMESTREAM_METRICS_DB_NAME"]
+    metrics_db_name = os.environ["METRICS_DB_NAME"]
     report_period_hours = int(os.environ["DIGEST_REPORT_PERIOD_HOURS"])
     settings = Settings.from_s3_path(
         base_path=settings_s3_path, iam_role_list_monitored_res=iam_role_name

--- a/src/lambda_digest.py
+++ b/src/lambda_digest.py
@@ -13,6 +13,12 @@ from lib.digest_service import (
     DigestDataAggregatorProvider,
 )
 
+from lib.metrics_storage import (
+    MetricsStorageProvider,
+    MetricsStorageTypes,
+    BaseMetricsStorage,
+)
+
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
@@ -173,7 +179,8 @@ def lambda_handler(event, context):
     settings_s3_path = os.environ["SETTINGS_S3_PATH"]
     iam_role_name = os.environ["IAMROLE_MONITORED_ACC_EXTRACT_METRICS"]
     notification_queue_url = os.environ["NOTIFICATION_QUEUE_URL"]
-    timestream_metrics_db_name = os.environ["TIMESTREAM_METRICS_DB_NAME"]
+    metrics_storage_type = MetricsStorageTypes.AWS_TIMESTREAM
+    metrics_db_name = os.environ["TIMESTREAM_METRICS_DB_NAME"]
     report_period_hours = int(os.environ["DIGEST_REPORT_PERIOD_HOURS"])
     settings = Settings.from_s3_path(
         base_path=settings_s3_path, iam_role_list_monitored_res=iam_role_name
@@ -184,16 +191,17 @@ def lambda_handler(event, context):
 
     # prepare digest data
     digest_data = []
-    metric_table_names = {
-        x: AWSNaming.TimestreamMetricsTable(None, x)
-        for x in SettingConfigs.RESOURCE_TYPES
-    }
+
+    metrics_storage: BaseMetricsStorage = MetricsStorageProvider.get_metrics_storage(
+        metrics_storage_type=metrics_storage_type,
+        db_name=metrics_db_name,
+    )
+
     for resource_type in SettingConfigs.RESOURCE_TYPES:
         # ceate an digest extractor for a specific resource type
         digest_extractor = DigestDataExtractorProvider.get_digest_provider(
+            metrics_storage=metrics_storage,
             resource_type=resource_type,
-            timestream_db_name=timestream_metrics_db_name,
-            timestream_table_name=metric_table_names[resource_type],
         )
         logger.info(f"Created digest extractor of type {type(digest_extractor)}")
         query = digest_extractor.get_query(digest_start_time, digest_end_time)

--- a/src/lambda_extract_metrics.py
+++ b/src/lambda_extract_metrics.py
@@ -234,7 +234,7 @@ def lambda_handler(event, context):
     # get vars from either ENV or Event
     settings_s3_path = os.environ["SETTINGS_S3_PATH"]
     iam_role_name = os.environ["IAMROLE_MONITORED_ACC_EXTRACT_METRICS"]
-    timestream_metrics_db_name = os.environ["TIMESTREAM_METRICS_DB_NAME"]
+    metrics_db_name = os.environ["METRICS_DB_NAME"]
     alerts_event_bus_name = os.environ["ALERTS_EVENT_BUS_NAME"]
     monitoring_group_name = event.get("monitoring_group")
     last_update_times = event.get("last_update_times")
@@ -242,7 +242,7 @@ def lambda_handler(event, context):
     # create storage object
     metrics_storage: BaseMetricsStorage = MetricsStorageProvider.get_metrics_storage(
         metrics_storage_type=storage_types.AWS_TIMESTREAM,
-        db_name=timestream_metrics_db_name,
+        db_name=metrics_db_name,
         write_client=TIMESTREAM_WRITE_CLIENT,
         query_client=TIMESTREAM_QUERY_CLIENT,
     )

--- a/src/lambda_extract_metrics_orch.py
+++ b/src/lambda_extract_metrics_orch.py
@@ -21,9 +21,7 @@ def lambda_handler(event, context):
     # Load environment variables
     settings_s3_path = os.environ["SETTINGS_S3_PATH"]
     lambda_extract_metrics_name = os.environ["LAMBDA_EXTRACT_METRICS_NAME"]
-
-    # todo: replace with METRICS_STORAGE_DB_NAME
-    timestream_metrics_db_name = os.environ["TIMESTREAM_METRICS_DB_NAME"]
+    metrics_db_name = os.environ["METRICS_DB_NAME"]
 
     # Step 1: Retrieve settings and list monitoring groups
     settings = Settings.from_s3_path(settings_s3_path)
@@ -32,7 +30,7 @@ def lambda_handler(event, context):
     # Step 2: Initialize Metrics Storage and retrieve last update times
     metrics_storage: BaseMetricsStorage = MetricsStorageProvider.get_metrics_storage(
         metrics_storage_type=storage_types.AWS_TIMESTREAM,
-        db_name=timestream_metrics_db_name,
+        db_name=metrics_db_name,
         query_client=TIMESTREAM_QUERY_CLIENT,
     )
 

--- a/src/lib/digest_service/digest_data_extractor.py
+++ b/src/lib/digest_service/digest_data_extractor.py
@@ -27,7 +27,7 @@ class BaseDigestDataExtractor(ABC):
         self.timestream_table_name = timestream_table_name
 
     @abstractmethod
-    def get_query(self, start_time: datetime, end_time: datetime):
+    def get_query(self, start_time: datetime, end_time: datetime) -> str:
         pass
 
     def extract_runs(self, query: str) -> dict:

--- a/src/lib/digest_service/digest_data_extractor_provider.py
+++ b/src/lib/digest_service/digest_data_extractor_provider.py
@@ -1,4 +1,4 @@
-from typing import Type
+from typing import Type, TypedDict, Unpack
 
 from lib.digest_service import (
     BaseDigestDataExtractor,
@@ -13,6 +13,12 @@ from lib.digest_service import (
 )
 
 from lib.core.constants import SettingConfigResourceTypes as types
+from lib.metrics_storage.base_metrics_storage import BaseMetricsStorage
+
+
+# params required to initialize DigestExtractor apart from resource_type
+class DigestExtractorKwargs(TypedDict):
+    metrics_storage: BaseMetricsStorage
 
 
 class DigestDataExtractorProvider:
@@ -30,7 +36,9 @@ class DigestDataExtractorProvider:
 
     # todo: start using typed kwargs (TypedDict, req python 3.12)
     @staticmethod
-    def get_digest_provider(resource_type: str, **kwargs) -> BaseDigestDataExtractor:
+    def get_digest_provider(
+        resource_type: str, **kwargs: Unpack[DigestExtractorKwargs]
+    ) -> BaseDigestDataExtractor:
         """Get digest extractor."""
         extractor = DigestDataExtractorProvider._digest_extractors.get(resource_type)
 

--- a/src/lib/digest_service/digest_data_extractor_provider.py
+++ b/src/lib/digest_service/digest_data_extractor_provider.py
@@ -1,3 +1,5 @@
+from typing import Type
+
 from lib.digest_service import (
     BaseDigestDataExtractor,
     GlueJobsDigestDataExtractor,
@@ -21,7 +23,7 @@ class DigestDataExtractorProvider:
     @staticmethod
     def register_digest_provider(
         resource_type: str,
-        digest_extractor: BaseDigestDataExtractor,
+        digest_extractor: Type[BaseDigestDataExtractor],
     ):
         """Register digest extractor."""
         DigestDataExtractorProvider._digest_extractors[resource_type] = digest_extractor

--- a/src/lib/digest_service/digest_data_extractor_provider.py
+++ b/src/lib/digest_service/digest_data_extractor_provider.py
@@ -28,7 +28,7 @@ class DigestDataExtractorProvider:
         """Register digest extractor."""
         DigestDataExtractorProvider._digest_extractors[resource_type] = digest_extractor
 
-    # todo: start using typed kwargs
+    # todo: start using typed kwargs (TypedDict, req python 3.12)
     @staticmethod
     def get_digest_provider(resource_type: str, **kwargs) -> BaseDigestDataExtractor:
         """Get digest extractor."""

--- a/src/lib/digest_service/digest_data_extractor_provider.py
+++ b/src/lib/digest_service/digest_data_extractor_provider.py
@@ -28,6 +28,7 @@ class DigestDataExtractorProvider:
         """Register digest extractor."""
         DigestDataExtractorProvider._digest_extractors[resource_type] = digest_extractor
 
+    # todo: start using typed kwargs
     @staticmethod
     def get_digest_provider(resource_type: str, **kwargs) -> BaseDigestDataExtractor:
         """Get digest extractor."""

--- a/src/lib/metrics_storage/__init__.py
+++ b/src/lib/metrics_storage/__init__.py
@@ -1,0 +1,2 @@
+from .base_metrics_storage import BaseMetricsStorage, MetricsStorageException
+from .metrics_storage_provider import MetricsStorageProvider, MetricsStorageTypes

--- a/src/lib/metrics_storage/base_metrics_storage.py
+++ b/src/lib/metrics_storage/base_metrics_storage.py
@@ -1,5 +1,7 @@
 from abc import ABC, abstractmethod
 
+from lib.aws.aws_naming import AWSNaming
+
 
 class MetricsStorageException(Exception):
     """Exception raised for errors encountered while working metrics storage."""
@@ -32,9 +34,22 @@ class BaseMetricsStorage:
         """
         pass
 
+    def get_metrics_table_name_for_resource_type(self, resource_type: str):
+        return AWSNaming.TimestreamMetricsTable(None, resource_type)
+
+    ####################################################################################################
+    # Read operations
+
     @abstractmethod
     def is_table_empty(self, table_name) -> bool:
         pass
+
+    @abstractmethod
+    def execute_query(self, query) -> list:
+        pass
+
+    ####################################################################################################
+    # Write operations
 
     @abstractmethod
     def write_records(self, table_name, records, common_attributes={}) -> list:

--- a/src/lib/metrics_storage/timestream_metrics_storage.py
+++ b/src/lib/metrics_storage/timestream_metrics_storage.py
@@ -34,13 +34,15 @@ class TimestreamMetricsStorage(BaseMetricsStorage):
         self._query_runner = None
 
     def writer(self, table_name):
-        if self._writer is None:
-            if self._write_client is None:
-                self._write_client = boto3.client("timestream-write")
+        if self._write_client is None:
+            self._write_client = boto3.client("timestream-write")
 
-            self._writer = TimestreamTableWriter(
-                self.db_name, table_name, self._write_client
-            )
+        # TimestreamTableWriter is created on each write instead of caching what is created once as table_name might differ
+        # for example - the same metrics_storage is created in lambda_extract_metrics and 2 different resource types are
+        # processed in one run
+        self._writer = TimestreamTableWriter(
+            self.db_name, table_name, self._write_client
+        )
         return self._writer
 
     @cached_property

--- a/src/lib/metrics_storage/timestream_metrics_storage.py
+++ b/src/lib/metrics_storage/timestream_metrics_storage.py
@@ -5,6 +5,7 @@ from lib.aws.timestream_manager import TimestreamTableWriter, TimeStreamQueryRun
 from lib.settings.settings import SettingConfigs
 from lib.core.datetime_utils import str_utc_datetime_to_datetime
 
+import boto3
 from lib.metrics_storage.base_metrics_storage import (
     BaseMetricsStorage,
     MetricsStorageException,
@@ -34,6 +35,9 @@ class TimestreamMetricsStorage(BaseMetricsStorage):
 
     def writer(self, table_name):
         if self._writer is None:
+            if self._write_client is None:
+                self._write_client = boto3.client("timestream-write")
+
             self._writer = TimestreamTableWriter(
                 self.db_name, table_name, self._write_client
             )
@@ -42,6 +46,8 @@ class TimestreamMetricsStorage(BaseMetricsStorage):
     @cached_property
     def query_runner(self) -> TimeStreamQueryRunner:
         if self._query_runner is None:
+            if self._query_client is None:
+                self._query_client = boto3.client("timestream-query")
             self._query_runner = TimeStreamQueryRunner(self._query_client)
         return self._query_runner
 

--- a/src/lib/metrics_storage/timestream_metrics_storage.py
+++ b/src/lib/metrics_storage/timestream_metrics_storage.py
@@ -3,7 +3,6 @@ from functools import cached_property
 
 from lib.aws.timestream_manager import TimestreamTableWriter, TimeStreamQueryRunner
 from lib.settings.settings import SettingConfigs
-from lib.aws.aws_naming import AWSNaming
 from lib.core.datetime_utils import str_utc_datetime_to_datetime
 
 from lib.metrics_storage.base_metrics_storage import (
@@ -55,10 +54,6 @@ class TimestreamMetricsStorage(BaseMetricsStorage):
 
     def _get_magnetic_store_retention_days(self, table_name):
         return self.writer(table_name).get_MagneticStoreRetentionPeriodInDays()
-
-    # todo: in phase 2 - move to BaseMetricStorage
-    def get_metrics_table_name_for_resource_type(self, resource_type: str):
-        return AWSNaming.TimestreamMetricsTable(None, resource_type)
 
     def get_earliest_writeable_time_for_resource_type(self, resource_type: str):
         table_name = self.get_metrics_table_name_for_resource_type(

--- a/tests/unit-tests/src/lib/digest_service/test_digest_data_extractor.py
+++ b/tests/unit-tests/src/lib/digest_service/test_digest_data_extractor.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 import re
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 import pytest
 from lib.core.constants import SettingConfigResourceTypes as types
 from lib.digest_service import (
@@ -36,6 +36,11 @@ START_TIME = datetime(2000, 1, 1, 0, 0, 0)
 END_TIME = datetime(2000, 1, 2, 0, 0, 0)
 
 
+@pytest.fixture
+def mocked_metrics_storage():
+    return MagicMock()
+
+
 @pytest.mark.parametrize(
     "scenario, resource_type",
     [
@@ -49,14 +54,10 @@ END_TIME = datetime(2000, 1, 2, 0, 0, 0)
         ("scen8", types.GLUE_DATA_CATALOGS),
     ],
 )
-def test_digest_extractor_get_query(scenario, resource_type):
-    timestream_db_name = f"timestream-salmon-metrics-events-storage-{STAGE_NAME}"
-    timestream_table_name = f"tstable-{resource_type}-metrics"
-
+def test_digest_extractor_get_query(scenario, resource_type, mocked_metrics_storage):
     returned_extractor = DigestDataExtractorProvider.get_digest_provider(
         resource_type=resource_type,
-        timestream_db_name=timestream_db_name,
-        timestream_table_name=timestream_table_name,
+        metrics_storage=mocked_metrics_storage,
     )
 
     returned_query = returned_extractor.get_query(START_TIME, END_TIME)
@@ -88,28 +89,24 @@ def test_digest_extractor_get_query(scenario, resource_type):
         ("scen8", types.EMR_SERVERLESS),
     ],
 )
-@patch("lib.digest_service.digest_data_extractor.TimeStreamQueryRunner")
-def test_digest_extract_runs_with_data(mock_query_runner, scenario, resource_type):
-    timestream_db_name = f"timestream-salmon-metrics-events-storage-{STAGE_NAME}"
-    timestream_table_name = f"tstable-{resource_type}-metrics"
+def test_digest_extract_runs_with_data(scenario, resource_type):
     query = "test_query"
+    metrics_table_name = "sample_table_name"
 
-    mock_runner_instance = mock_query_runner.return_value
-    mock_runner_instance.is_table_empty.return_value = False
-    mock_runner_instance.execute_query.return_value = {"data": "sample_data"}
+    mocked_metrics_storage = MagicMock()
+    mocked_metrics_storage.is_table_empty.return_value = False
+    mocked_metrics_storage.execute_query.return_value = {"data": "sample_data"}
 
     returned_extractor = DigestDataExtractorProvider.get_digest_provider(
         resource_type=resource_type,
-        timestream_db_name=timestream_db_name,
-        timestream_table_name=timestream_table_name,
+        metrics_storage=mocked_metrics_storage,
     )
+    returned_extractor.table_name = metrics_table_name
 
     result = returned_extractor.extract_runs(query)
 
-    mock_runner_instance.is_table_empty.assert_called_once_with(
-        timestream_db_name, timestream_table_name
-    )
-    mock_runner_instance.execute_query.assert_called_once_with(query)
+    mocked_metrics_storage.is_table_empty.assert_called_once_with(metrics_table_name)
+    mocked_metrics_storage.execute_query.assert_called_once_with(query)
     assert result == {resource_type: {"data": "sample_data"}}
 
 
@@ -126,27 +123,23 @@ def test_digest_extract_runs_with_data(mock_query_runner, scenario, resource_typ
         ("scen8", types.EMR_SERVERLESS),
     ],
 )
-@patch("lib.digest_service.digest_data_extractor.TimeStreamQueryRunner")
-def test_digest_extract_runs_no_data(mock_query_runner, scenario, resource_type):
-    timestream_db_name = f"timestream-salmon-metrics-events-storage-{STAGE_NAME}"
-    timestream_table_name = f"tstable-{resource_type}-metrics"
+def test_digest_extract_runs_no_data(scenario, resource_type):
     query = "test_query"
+    metrics_table_name = "sample_table_name"
 
-    mock_runner_instance = mock_query_runner.return_value
-    mock_runner_instance.is_table_empty.return_value = True
+    mocked_metrics_storage = MagicMock()
+    mocked_metrics_storage.is_table_empty.return_value = True
 
     returned_extractor = DigestDataExtractorProvider.get_digest_provider(
         resource_type=resource_type,
-        timestream_db_name=timestream_db_name,
-        timestream_table_name=timestream_table_name,
+        metrics_storage=mocked_metrics_storage,
     )
+    returned_extractor.table_name = metrics_table_name
 
     result = returned_extractor.extract_runs(query)
 
-    mock_runner_instance.is_table_empty.assert_called_once_with(
-        timestream_db_name, timestream_table_name
-    )
-    mock_runner_instance.execute_query.assert_not_called()
+    mocked_metrics_storage.is_table_empty.assert_called_once_with(metrics_table_name)
+    mocked_metrics_storage.execute_query.assert_not_called()
     assert result == {}
 
 
@@ -163,25 +156,21 @@ def test_digest_extract_runs_no_data(mock_query_runner, scenario, resource_type)
         ("scen8", types.EMR_SERVERLESS),
     ],
 )
-@patch("lib.digest_service.digest_data_extractor.TimeStreamQueryRunner")
-def test_digest_extract_runs_exception(mock_query_runner, scenario, resource_type):
-    timestream_db_name = f"timestream-salmon-metrics-events-storage-{STAGE_NAME}"
-    timestream_table_name = f"tstable-{resource_type}-metrics"
+def test_digest_extract_runs_exception(scenario, resource_type):
     query = "test_query"
+    metrics_table_name = "sample_table_name"
 
-    mock_runner_instance = mock_query_runner.return_value
-    mock_runner_instance.is_table_empty.side_effect = Exception("Can't connect to DB")
+    mocked_metrics_storage = MagicMock()
+    mocked_metrics_storage.is_table_empty.side_effect = Exception("Can't connect to DB")
 
     returned_extractor = DigestDataExtractorProvider.get_digest_provider(
         resource_type=resource_type,
-        timestream_db_name=timestream_db_name,
-        timestream_table_name=timestream_table_name,
+        metrics_storage=mocked_metrics_storage,
     )
+    returned_extractor.table_name = metrics_table_name
 
     with pytest.raises(DigestException):
         returned_extractor.extract_runs(query)
 
-    mock_runner_instance.is_table_empty.assert_called_once_with(
-        timestream_db_name, timestream_table_name
-    )
-    mock_runner_instance.execute_query.assert_not_called()
+    mocked_metrics_storage.is_table_empty.assert_called_once_with(metrics_table_name)
+    mocked_metrics_storage.execute_query.assert_not_called()

--- a/tests/unit-tests/src/lib/digest_service/test_digest_data_extractor_provider.py
+++ b/tests/unit-tests/src/lib/digest_service/test_digest_data_extractor_provider.py
@@ -13,6 +13,7 @@ from lib.digest_service import (
     DigestDataExtractorProvider,
 )
 
+from lib.metrics_storage import MetricsStorageTypes
 
 STAGE_NAME = "teststage"
 
@@ -51,13 +52,12 @@ def test_unregistered_resource_type():
     ],
 )
 def test_get_digest_provider(scenario, resource_type, expected_extractor):
+    metric_storage_type = MetricsStorageTypes.AWS_TIMESTREAM
     timestream_db_name = f"timestream-salmon-metrics-events-storage-{STAGE_NAME}"
-    timestream_table_name = f"tstable-{resource_type}-metrics"
 
     returned_extractor = DigestDataExtractorProvider.get_digest_provider(
         resource_type=resource_type,
         timestream_db_name=timestream_db_name,
-        timestream_table_name=timestream_table_name,
     )
     assert isinstance(returned_extractor, expected_extractor)
     assert str(expected_extractor) in str(type(returned_extractor))

--- a/tests/unit-tests/src/lib/digest_service/test_digest_data_extractor_provider.py
+++ b/tests/unit-tests/src/lib/digest_service/test_digest_data_extractor_provider.py
@@ -1,3 +1,4 @@
+from unittest.mock import MagicMock
 import pytest
 from lib.core.constants import SettingConfigResourceTypes as types, SettingConfigs
 from lib.digest_service import (
@@ -18,24 +19,27 @@ from lib.metrics_storage import MetricsStorageTypes
 STAGE_NAME = "teststage"
 
 
-def test_all_resource_types_registered():
-    for resource_type in SettingConfigs.RESOURCE_TYPES:
-        timestream_db_name = f"timestream-salmon-metrics-events-storage-{STAGE_NAME}"
-        timestream_table_name = f"tstable-{resource_type}-metrics"
+@pytest.fixture
+def mocked_metrics_storage():
+    return MagicMock()
 
+
+def test_all_resource_types_registered(mocked_metrics_storage):
+    for resource_type in SettingConfigs.RESOURCE_TYPES:
         returned_extractor = DigestDataExtractorProvider.get_digest_provider(
             resource_type=resource_type,
-            timestream_db_name=timestream_db_name,
-            timestream_table_name=timestream_table_name,
+            metrics_storage=mocked_metrics_storage,
         )
         assert (
             returned_extractor is not None
         ), f"No extractor found for resource type {resource_type}"
 
 
-def test_unregistered_resource_type():
+def test_unregistered_resource_type(mocked_metrics_storage):
     with pytest.raises(ValueError):
-        DigestDataExtractorProvider.get_digest_provider("unregistered_type")
+        DigestDataExtractorProvider.get_digest_provider(
+            resource_type="unregistered_type", metrics_storage=mocked_metrics_storage
+        )
 
 
 @pytest.mark.parametrize(
@@ -51,13 +55,12 @@ def test_unregistered_resource_type():
         ("scen8", types.EMR_SERVERLESS, EMRServerlessDigestDataExtractor),
     ],
 )
-def test_get_digest_provider(scenario, resource_type, expected_extractor):
-    metric_storage_type = MetricsStorageTypes.AWS_TIMESTREAM
-    timestream_db_name = f"timestream-salmon-metrics-events-storage-{STAGE_NAME}"
-
+def test_get_digest_provider(
+    scenario, resource_type, expected_extractor, mocked_metrics_storage
+):
     returned_extractor = DigestDataExtractorProvider.get_digest_provider(
         resource_type=resource_type,
-        timestream_db_name=timestream_db_name,
+        metrics_storage=mocked_metrics_storage,
     )
     assert isinstance(returned_extractor, expected_extractor)
     assert str(expected_extractor) in str(type(returned_extractor))

--- a/tests/unit-tests/src/test_lambda_digest.py
+++ b/tests/unit-tests/src/test_lambda_digest.py
@@ -20,16 +20,16 @@ STAGE_NAME = "teststage"
 def os_vars_init(aws_props_init):
     # Sets up necessary lambda OS vars
     (account_id, region) = aws_props_init
-    os.environ[
-        "NOTIFICATION_QUEUE_URL"
-    ] = f"https://sqs.{region}.amazonaws.com/{account_id}/queue-salmon-notification-{STAGE_NAME}.fifo"
+    os.environ["NOTIFICATION_QUEUE_URL"] = (
+        f"https://sqs.{region}.amazonaws.com/{account_id}/queue-salmon-notification-{STAGE_NAME}.fifo"
+    )
     os.environ["SETTINGS_S3_PATH"] = f"s3://s3-salmon-settings-{STAGE_NAME}/settings/"
-    os.environ[
-        "IAMROLE_MONITORED_ACC_EXTRACT_METRICS"
-    ] = f"role-salmon-monitored-acc-extract-metrics-{STAGE_NAME}"
-    os.environ[
-        "TIMESTREAM_METRICS_DB_NAME"
-    ] = f"timestream-salmon-metrics-events-storage-{STAGE_NAME}"
+    os.environ["IAMROLE_MONITORED_ACC_EXTRACT_METRICS"] = (
+        f"role-salmon-monitored-acc-extract-metrics-{STAGE_NAME}"
+    )
+    os.environ["METRICS_DB_NAME"] = (
+        f"timestream-salmon-metrics-events-storage-{STAGE_NAME}"
+    )
     os.environ["DIGEST_REPORT_PERIOD_HOURS"] = "24"
 
 

--- a/tests/unit-tests/src/test_lambda_extract_metrics.py
+++ b/tests/unit-tests/src/test_lambda_extract_metrics.py
@@ -544,7 +544,7 @@ class TestLambdaHandler:
             {
                 "SETTINGS_S3_PATH": "s3://test-bucket/settings.json",
                 "IAMROLE_MONITORED_ACC_EXTRACT_METRICS": "test-iam-role",
-                "TIMESTREAM_METRICS_DB_NAME": "test-db",
+                "METRICS_DB_NAME": "test-db",
                 "ALERTS_EVENT_BUS_NAME": "test-event-bus",
             },
         )

--- a/tests/unit-tests/src/test_lambda_extract_metrics_orch.py
+++ b/tests/unit-tests/src/test_lambda_extract_metrics_orch.py
@@ -48,12 +48,12 @@ def os_vars_init(aws_props_init):
     (account_id, region) = aws_props_init
     stage_name = "teststage"
     os.environ["SETTINGS_S3_PATH"] = f"s3://s3-salmon-settings-{stage_name}/settings/"
-    os.environ[
-        "LAMBDA_EXTRACT_METRICS_NAME"
-    ] = f"lambda-salmon-extract-metrics-{stage_name}"
-    os.environ[
-        "TIMESTREAM_METRICS_DB_NAME"
-    ] = f"timestream-salmon-metrics-events-storage-{stage_name}"
+    os.environ["LAMBDA_EXTRACT_METRICS_NAME"] = (
+        f"lambda-salmon-extract-metrics-{stage_name}"
+    )
+    os.environ["METRICS_DB_NAME"] = (
+        f"timestream-salmon-metrics-events-storage-{stage_name}"
+    )
 
 
 #########################################################################################


### PR DESCRIPTION
1. Refactor digest (lambda, extractor, extractor_provider) to use metrics_storage, but not TimestreamQueryRunner directly
2. Renamed lambda config env params TIMESTREAM_METRICS_DB_NAME -> METRICS_DB_NAME
3. Upgraded aws_cdk_lib 2.103 -> 2.174 (required to use PYTHON_3_13 in lambdas).
4. Upgrading aws_cdk_lib broke CDK monitored stack (Error: Cannot use a service or account principal with grantAssumeRole, use assumeRolePolicy instead.)
5. Now digest_extract_provider uses TypedDict for **kwargs